### PR TITLE
support for custom json-rpc-server urls

### DIFF
--- a/.env.custom_node
+++ b/.env.custom_node
@@ -7,3 +7,4 @@ NODE_TIMEOUT=30000 # Time after which the tests would fail if the mirror node do
 MIRROR_NETWORK=127.0.0.1:5600
 MIRROR_NODE_REST_URL=http://127.0.0.1:5551
 MIRROR_NODE_REST_JAVA_URL=http://127.0.0.1:8084
+JSON_RPC_SERVER_URL="http://localhost:8545/"

--- a/.env.testnet
+++ b/.env.testnet
@@ -4,3 +4,4 @@ OPERATOR_ACCOUNT_PRIVATE_KEY=***
 NODE_TIMEOUT=30000 # Time after which the tests would fail if the mirror node does not have the data
 MIRROR_NODE_REST_URL=https://testnet.mirrornode.hedera.com
 MIRROR_NODE_REST_JAVA_URL=https://testnet.mirrornode.hedera.com
+JSON_RPC_SERVER_URL="http://localhost:8545/"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ In near future hedera-local-node will be transfered to Hiero (see our [transitio
 
 Start only the JSON-RPC server for the SDK you want to test. The JSON-RPC server for the specified SDK will parse the JSON formatted request received by the test driver. The JSON-RPC server will execute the corresponding function or procedure associated with that method and prepare the response in JSON format to send back to the test driver. 
 
+By default, the TCK will look for a JSON-RPC Server at: `http://localhost:8545/`, but this can be configured by changing the `JSON_RPC_SERVER_URL` in your `.env` file:
+
 ### Install and run
 
 Install packages with npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "hedera-sdk-tck",
+  "name": "hiero-sdk-tck",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/services/Client.ts
+++ b/src/services/Client.ts
@@ -10,11 +10,15 @@ const createID: CreateID = () => nextID++;
 const JSONRPClient = new JSONRPCClient(
   async (jsonRPCRequest): Promise<void> => {
     try {
-      const response = await axios.post("http://localhost", jsonRPCRequest, {
-        headers: {
-          "Content-Type": "application/json",
+      const response = await axios.post(
+        process.env.JSON_RPC_SERVER_URL ?? "http://localhost:8545",
+        jsonRPCRequest,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
         },
-      });
+      );
 
       if (response.status === 200) {
         return JSONRPClient.receive(response.data);


### PR DESCRIPTION
Added a new environment variable: "JSON_RPC_SERVER_URL" which defaults to "http://localhost:8545/" which is the normal json rpc server port. Also made sure that Client.ts defaults to the same url when no environment variable is found.

This fixes issue #325 