### PR TITLE
fix: Clean up logic around `Dockerization` of the TCK

### DIFF
--- a/.env.custom_node
+++ b/.env.custom_node
@@ -1,10 +1,28 @@
 # local node default values
+
+# The account ID of the operator in the local or any custom network, which is used to sign transactions
 OPERATOR_ACCOUNT_ID=0.0.1022
+
+# The private key of the operator account in the local or any custom network, used for signing transactions
 OPERATOR_ACCOUNT_PRIVATE_KEY=302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4
+
+# The IP address and port of the local node
 NODE_IP=127.0.0.1:50211
+
+# The account ID of the node in the local or any custom network, used to identify the node in the network
 NODE_ACCOUNT_ID=0.0.3
-NODE_TIMEOUT=30000 # Time after which the tests would fail if the mirror node does not have the data
+
+# The timeout duration (in milliseconds) for node operations, after which tests will fail if the mirror node does not have the data
+NODE_TIMEOUT=30000
+
+# The IP address and port of the local or any custom mirror network
 MIRROR_NETWORK=127.0.0.1:5600
+
+# The REST API URL for the local or any custom mirror node
 MIRROR_NODE_REST_URL=http://127.0.0.1:5551
+
+# The Java-based REST API URL for the local or any custom mirror node
 MIRROR_NODE_REST_JAVA_URL=http://127.0.0.1:8084
+
+# The URL for the JSON-RPC server which expecting the tests to be run against
 JSON_RPC_SERVER_URL="http://localhost:8544/"

--- a/.env.custom_node
+++ b/.env.custom_node
@@ -6,7 +6,7 @@ OPERATOR_ACCOUNT_ID=0.0.1022
 # The private key of the operator account in the local or any custom network, used for signing transactions
 OPERATOR_ACCOUNT_PRIVATE_KEY=302e020100300506032b657004220420a608e2130a0a3cb34f86e757303c862bee353d9ab77ba4387ec084f881d420d4
 
-# The IP address and port of the local node
+# The IP address and port of the local node or any custom node
 NODE_IP=127.0.0.1:50211
 
 # The account ID of the node in the local or any custom network, used to identify the node in the network

--- a/.env.testnet
+++ b/.env.testnet
@@ -1,7 +1,19 @@
 # get ECDSA keys for testnet from https://portal.hedera.com/
+
+# The account ID of the operator, which is used to sign transactions
 OPERATOR_ACCOUNT_ID=***
+
+# The private key of the operator account, used for signing transactions
 OPERATOR_ACCOUNT_PRIVATE_KEY=***
-NODE_TIMEOUT=30000 # Time after which the tests would fail if the mirror node does not have the data
+
+# The timeout duration (in milliseconds) for node operations, after which tests will fail if the mirror node does not have the data
+NODE_TIMEOUT=30000
+
+# The REST API URL for the testnet mirror node
 MIRROR_NODE_REST_URL=https://testnet.mirrornode.hedera.com
+
+# The Java-based REST API URL for the testnet mirror node
 MIRROR_NODE_REST_JAVA_URL=https://testnet.mirrornode.hedera.com
+
+# The URL for the JSON-RPC server
 JSON_RPC_SERVER_URL="http://localhost:8544/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN npm ci
 
 # Environment Variables
 ENV NETWORK=local \
-    RUNNING_IN_DOCKER=true \
     TEST="ALL" 
 
 # Copy the rest of the application

--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ docker run --network host -e JSON_RPC_SERVER_URL=http://host.docker.internal:${Y
 
 ```
 
+### Configuring any custom local network
+To run tests against any other custom local network, you need to set the following environment variables:
+
+| Environment Variable         | Description                              |
+|------------------------------|------------------------------------------     |
+| `OPERATOR_ACCOUNT_ID`        | The account ID of the operator           |
+| `OPERATOR_ACCOUNT_PRIVATE_KEY` | The private key of the operator account |
+| `JSON_RPC_SERVER_URL`        | The URL of the JSON-RPC server           |
+
+For a complete list of configurable environment variables, refer to the `.env.custom_node` file. This file contains default values and descriptions for each variable, which can be adjusted to fit your custom network setup.
+
 #### Testnet
 To run tests against Hedera Testnet:
 ```bash
@@ -199,7 +210,7 @@ RunTestsInContainer.ts
 
 ## Contributing
 
-Whether you’re fixing bugs, enhancing features, or improving documentation, your contributions are important — let’s build something great together!
+Whether you're fixing bugs, enhancing features, or improving documentation, your contributions are important — let's build something great together!
 
 Please read our [contributing guide](https://github.com/hiero-ledger/.github/blob/main/CONTRIBUTING.md) to see how you can get involved.
 

--- a/README.md
+++ b/README.md
@@ -131,10 +131,13 @@ The Docker image supports running tests against both local and testnet environme
 To run tests against a local network:
 ```bash
 # Run specific test
-docker run --network host -e TEST=AccountCreate ivaylogarnev/tck-client
+docker run --network host -e TEST=AccountCreate -e  JSON_RPC_SERVER_URL=http://host.docker.internal:${YOUR_SERVER_PORT}  ivaylogarnev/tck-client
+
+#the default port is 8544
 
 # Run all tests
-docker run --network host ivaylogarnev/tck-client
+docker run --network host -e JSON_RPC_SERVER_URL=http://host.docker.internal:${YOUR_SERVER_PORT} ivaylogarnev/tck-client
+
 ```
 
 #### Testnet
@@ -144,6 +147,7 @@ docker run --network host \
   -e NETWORK=testnet \
   -e OPERATOR_ACCOUNT_ID=your-account-id \
   -e OPERATOR_ACCOUNT_PRIVATE_KEY=your-private-key \
+  -e  JSON_RPC_SERVER_URL=http://host.docker.internal:${YOUR_SERVER_PORT} 
   # Run specific test
   -e TEST=AccountCreate \
   ivaylogarnev/tck-client

--- a/src/services/Client.ts
+++ b/src/services/Client.ts
@@ -5,26 +5,20 @@ import "dotenv/config";
 let nextID = 0;
 const createID: CreateID = () => nextID++;
 
-// Determine the host based on environment
-const getHost = () => {
-  const url = process.env.JSON_RPC_SERVER_URL ?? "http://localhost:8544";
-
-  if (process.env.RUNNING_IN_DOCKER) {
-    return url.replace("localhost", "host.docker.internal");
-  }
-  return url;
-};
-
 // JSONRPCClient needs to know how to send a JSON-RPC request.
 // Tell it by passing a function to its constructor. The function must take a JSON-RPC request and send it.
 const JSONRPClient = new JSONRPCClient(
   async (jsonRPCRequest): Promise<void> => {
     try {
-      const response = await axios.post(getHost(), jsonRPCRequest, {
-        headers: {
-          "Content-Type": "application/json",
+      const response = await axios.post(
+        process.env.JSON_RPC_SERVER_URL ?? "http://localhost:8544",
+        jsonRPCRequest,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
         },
-      });
+      );
 
       if (response.status === 200) {
         return JSONRPClient.receive(response.data);


### PR DESCRIPTION
Description:
This PR clean ups `JSON_RPC_SERVER_URL` condition check and instead rely on the env passed to the docker image and updates the `README`.

Checklist
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)