### PR TITLE
macOS docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ docker run --network host \
   -e TEST=AccountCreate \
   ivaylogarnev/tck-client
 ```
+### macOS Docker setup
+macOS lacks native support for Docker due to its lack of native support for Linux.
+You'll have to do two things to run the TCK as a Docker image on macOS.
+
+1. Download the Docker Desktop app (https://docs.docker.com/desktop/setup/install/mac-install/)
+2. Enable Host Networking; after downloading the Docker Desktop app, go to  
+   Settings -> Resources -> Network, turn on "Enable Host Networking."
+   (I'd recommend reducing Docker's access to memory, RAM, and other various resources; by default,
+   it has access to more resources than most Macs have.)
+
+Once you download Docker Desktop and enable Host Networking, you can run the test commands in the CLI as shown above.
 
 ### Available Tests
 Some of the available test options include:


### PR DESCRIPTION
**Description**:
After digging around a little bit on the internet, I learned that --network host isn't supported by default on macOS; it has to be enabled in the Docker Desktop app also because Linux doesn't have native support, and as such, most people use Docker through the desktop app (at least to get Docker setup).

I added further instructions to the README to clarify Docker usage for macOS.
I don't know if this is common knowledge among people, but it may be helpful for people who are using Docker to communicate with localhost.

**Related issue(s)**:

Fixes #342 

**Notes for reviewer**:
There are no code changes, just further instructions in the README under the Docker section

**Checklist**
- [x] Documented (README)
