### PR TITLE
ci: Change runner type for title and assignee checks

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   title-check:
     name: Title Check
-    runs-on: hiero-network-node-linux-medium
+    runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -45,7 +45,7 @@ jobs:
           
   assignee-check:
     name: Assignee Check
-    runs-on: hiero-network-node-linux-medium
+    runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0


### PR DESCRIPTION
**Description**:

This pull request updates the GitHub Actions workflow configuration to improve runner selection for CI jobs. The most important changes are:

**Infrastructure updates:**

* Changed the runner type for the `title-check` job in `.github/workflows/pr_check.yml` from `hiero-network-node-linux-medium` to `hiero-client-sdk-linux-medium` to align with current infrastructure standards.
* Changed the runner type for the `assignee-check` job in `.github/workflows/pr_check.yml` from `hiero-network-node-linux-medium` to `hiero-client-sdk-linux-medium` for consistency and improved resource usage.

**Related issue(s)**:

Fixes #533
