### PR TITLE
fix: Align TopicMessageSubmitTransaction test #7 with specification

### DIFF
--- a/src/tests/topic-service/test-topic-message-submit-transaction.ts
+++ b/src/tests/topic-service/test-topic-message-submit-transaction.ts
@@ -436,9 +436,9 @@ describe("TopicMessageSubmitTransaction", function () {
         });
       } catch (err: any) {
         assert.equal(
-          err.code,
-          ErrorStatusCodes.INTERNAL_ERROR,
-          "Internal error",
+          err.data.status,
+          "INVALID_TOPIC_MESSAGE",
+          "Invalid topic message error",
         );
         return;
       }


### PR DESCRIPTION
## Summary

This PR fixes a test assertion mismatch in the `TopicMessageSubmitTransaction` Message test #7 ("Submits a message without message content to a public topic"). The test implementation was asserting a JSON-RPC internal error (`-32603`), but the [test specification](docs/test-specifications/topic-service/TopicMessageSubmitTransaction.md) defines the expected response as `INVALID_TOPIC_MESSAGE` — a Hedera network status error. This was exposed by [hiero-sdk-js#3738](https://github.com/hiero-ledger/hiero-sdk-js/pull/3738), which correctly removed a redundant client-side validation that had been masking the incorrect assertion.

## Motivation

The TCK regression workflow in `hiero-consensus-node` began failing after the JS SDK released `v2.81.0-beta.1`. The root cause was **not** in the JS SDK — the SDK change was correct per the TCK spec. The issue was that the TCK test had an incorrect assertion that only passed by coincidence due to a client-side `throw new Error("Message is required")` in the JS SDK's TCK server, which has since been properly removed.

The test specification clearly states:

| Test no | Name | Expected response |
|---------|------|-------------------|
| 7 | Submits a message without message content to a public topic | The message submission fails with an `INVALID_TOPIC_MESSAGE` |

This is a Hedera network status error, not an SDK internal error, and should be asserted the same way as all other Hedera status errors in the test file (via `err.data.status`).

## Changes

### Test Assertion Fix

Updated the assertion in Message test no. 7 to check `err.data.status === "INVALID_TOPIC_MESSAGE"` instead of `err.code === ErrorStatusCodes.INTERNAL_ERROR`, aligning with:

1. The [test specification](docs/test-specifications/topic-service/TopicMessageSubmitTransaction.md) (Message test no. 7)
2. The assertion pattern used by every other Hedera status error test in the same file (e.g., `INVALID_TOPIC_ID` in TopicId tests no. 2, no. 4, no. 5)

**Before:**
```typescript
assert.equal(
  err.code,
  ErrorStatusCodes.INTERNAL_ERROR,
  "Internal error",
);
```

**After:**
```typescript
assert.equal(
  err.data.status,
  "INVALID_TOPIC_MESSAGE",
  "Invalid topic message error",
);
```

## Testing

**Test Plan:**
- [ ] Run full TCK suite against JS SDK TCK server with a local Hiero network
- [ ] Verify Message test no. 7 passes with the corrected assertion
- [ ] Verify no other tests are affected

```bash
npm run test  # Full TCK suite
npm run test:file -- src/tests/topic-service/test-topic-message-submit-transaction.ts  # Just this file
```

## Files Changed Summary

| Category | Files | Notes |
|----------|-------|-------|
| Test | `src/tests/topic-service/test-topic-message-submit-transaction.ts` | Fixed assertion for Message test no. 7 |

## Breaking Changes

**None.** This corrects an incorrect test assertion to match the existing specification. No public APIs or test interfaces are changed.
