### PR TITLE
fix: update contractInfoQuery tests

### DIFF
--- a/docs/test-specifications/contract-service/ContractInfoQuery.md
+++ b/docs/test-specifications/contract-service/ContractInfoQuery.md
@@ -40,14 +40,16 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 
 | Parameter Name     | Type   | Required/Optional | Description/Notes                                                                        |
 |--------------------|--------|-------------------|------------------------------------------------------------------------------------------|
-| contractId         | string | optional          | The ID of the contract to query.                                                         |
-| queryPayment       | string | optional          | The exact payment amount in tinybars to be paid for this query. This sets a fixed payment amount. |
-| maxQueryPayment    | string | optional          | The maximum payment amount in tinybars willing to be paid for this query. The SDK will check the query cost first and only execute if the cost is within this maximum. This prevents overpayment. Examples: 1 (minimum), 100000000 (1 HBAR), 1000000000000 (large amount). |
+| contractId         | string  | optional          | The ID of the contract to query.                                                         |
+| queryPayment       | string  | optional          | The exact payment amount in tinybars to be paid for this query. This sets a fixed payment amount. |
+| maxQueryPayment    | string  | optional          | The maximum payment amount in tinybars willing to be paid for this query. The SDK will check the query cost first and only execute if the cost is within this maximum. This prevents overpayment. Examples: 1 (minimum), 100000000 (1 HBAR), 1000000000000 (large amount). |
+| getCost            | boolean | optional          | If true, returns only the cost of the query in tinybars without executing it.            |
 
 ### Output Parameters
 
 | Parameter Name                    | Type    | Description/Notes                                                                |
 |-----------------------------------|---------|----------------------------------------------------------------------------------|
+| cost                              | string  | The query cost in tinybars (only returned when getCost=true).                   |
 | contractId                        | string  | The smart contract instance ID.                                                 |
 | accountId                         | string  | The account ID associated with the contract.                                     |
 | contractAccountId                 | string  | The contract account ID (if applicable).                                         |
@@ -82,7 +84,7 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 | 3       | Fails to execute with non-existent contract ID                   | contractId=123.456.789   | The contract info query fails and returns INVALID_CONTRACT_ID                                 | Y                 |
 | 4       | Executes query with explicit maxQueryPayment amount              | maxQueryPayment=100000000| Query succeeds and returns contract info                                                       | Y                 |
 | 5       | Executes query with explicit queryPayment amount                 | queryPayment=100000000    | Query succeeds and returns contract info                                                       | Y                 |
-| 6       | Executes query and retrieves cost                                | contractId=<VALID_ID>    | Query succeeds and returns cost information                                                   | Y                 |
+| 6       | Executes query and retrieves cost                                | contractId=<VALID_ID>, getCost=true | Query succeeds and returns cost as a numeric string greater than 0                    | Y                 |
 | 7       | Response contains contract ID and account ID                     | contractId=<VALID_ID>    | Returns contractId matching input and accountId with correct format                          | Y                 |
 | 8       | Response contains admin key                                      | contractId=<VALID_ID>    | Returns adminKey (if set)                                                                     | Y                 |
 | 9       | Response contains expiration time                                | contractId=<VALID_ID>    | Returns expirationTime                                                                         | Y                 |

--- a/docs/test-specifications/contract-service/ContractInfoQuery.md
+++ b/docs/test-specifications/contract-service/ContractInfoQuery.md
@@ -43,13 +43,12 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 | contractId         | string  | optional          | The ID of the contract to query.                                                         |
 | queryPayment       | string  | optional          | The exact payment amount in tinybars to be paid for this query. This sets a fixed payment amount. |
 | maxQueryPayment    | string  | optional          | The maximum payment amount in tinybars willing to be paid for this query. The SDK will check the query cost first and only execute if the cost is within this maximum. This prevents overpayment. Examples: 1 (minimum), 100000000 (1 HBAR), 1000000000000 (large amount). |
-| getCost            | boolean | optional          | If true, returns only the cost of the query in tinybars without executing it.            |
+
 
 ### Output Parameters
 
 | Parameter Name                    | Type    | Description/Notes                                                                |
 |-----------------------------------|---------|----------------------------------------------------------------------------------|
-| cost                              | string  | The query cost in tinybars (only returned when getCost=true).                   |
 | contractId                        | string  | The smart contract instance ID.                                                 |
 | accountId                         | string  | The account ID associated with the contract.                                     |
 | contractAccountId                 | string  | The contract account ID (if applicable).                                         |
@@ -84,18 +83,17 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 | 3       | Fails to execute with non-existent contract ID                   | contractId=123.456.789   | The contract info query fails and returns INVALID_CONTRACT_ID                                 | Y                 |
 | 4       | Executes query with explicit maxQueryPayment amount              | maxQueryPayment=100000000| Query succeeds and returns contract info                                                       | Y                 |
 | 5       | Executes query with explicit queryPayment amount                 | queryPayment=100000000    | Query succeeds and returns contract info                                                       | Y                 |
-| 6       | Executes query and retrieves cost                                | contractId=<VALID_ID>, getCost=true | Query succeeds and returns cost as a numeric string greater than 0                    | Y                 |
-| 7       | Response contains contract ID and account ID                     | contractId=<VALID_ID>    | Returns contractId matching input and accountId with correct format                          | Y                 |
-| 8       | Response contains admin key                                      | contractId=<VALID_ID>    | Returns adminKey (if set)                                                                     | Y                 |
-| 9       | Response contains expiration time                                | contractId=<VALID_ID>    | Returns expirationTime                                                                         | Y                 |
-| 10      | Response contains auto-renew period                              | contractId=<VALID_ID>    | Returns autoRenewPeriod                                                                        | Y                 |
-| 11      | Response contains contract balance                               | contractId=<VALID_ID>    | Returns balance in tinybars                                                                    | Y                 |
-| 12      | Response contains contract memo                                  | contractId=<VALID_ID>    | Returns contractMemo (if set)                                                                 | Y                 |
-| 13      | Response contains isDeleted flag                                 | contractId=<VALID_ID>    | Returns isDeleted boolean                                                                     | Y                 |
-| 14      | Response contains storage information                            | contractId=<VALID_ID>    | Returns storage value                                                                          | Y                 |
-| 15      | Response contains contract account ID                            | contractId=<VALID_ID>    | Returns contractAccountId (if applicable)                                                     | Y                 |
-| 16      | Response contains auto-renew account ID                          | contractId=<VALID_ID>    | Returns autoRenewAccountId (if set)                                                            | Y                 |
-| 17      | Response contains max automatic token associations               | contractId=<VALID_ID>    | Returns maxAutomaticTokenAssociations                                                          | Y                 |
-| 18      | Response contains ledger ID                                      | contractId=<VALID_ID>    | Returns ledgerId                                                                               | Y                 |
-| 19      | Response contains staking info when applicable                   | contractId=<VALID_ID>    | Returns stakingInfo object with all sub-fields (if staked)                                    | Y                 |
+| 6       | Response contains contract ID and account ID                     | contractId=<VALID_ID>    | Returns contractId matching input and accountId with correct format                          | Y                 |
+| 7       | Response contains admin key                                      | contractId=<VALID_ID>    | Returns adminKey (if set)                                                                     | Y                 |
+| 8       | Response contains expiration time                                | contractId=<VALID_ID>    | Returns expirationTime                                                                         | Y                 |
+| 9       | Response contains auto-renew period                              | contractId=<VALID_ID>    | Returns autoRenewPeriod                                                                        | Y                 |
+| 10      | Response contains contract balance                               | contractId=<VALID_ID>    | Returns balance in tinybars                                                                    | Y                 |
+| 11      | Response contains contract memo                                  | contractId=<VALID_ID>    | Returns contractMemo (if set)                                                                 | Y                 |
+| 12      | Response contains isDeleted flag                                 | contractId=<VALID_ID>    | Returns isDeleted boolean                                                                     | Y                 |
+| 13      | Response contains storage information                            | contractId=<VALID_ID>    | Returns storage value                                                                          | Y                 |
+| 14      | Response contains contract account ID                            | contractId=<VALID_ID>    | Returns contractAccountId (if applicable)                                                     | Y                 |
+| 15      | Response contains auto-renew account ID                          | contractId=<VALID_ID>    | Returns autoRenewAccountId (if set)                                                            | Y                 |
+| 16      | Response contains max automatic token associations               | contractId=<VALID_ID>    | Returns maxAutomaticTokenAssociations                                                          | Y                 |
+| 17      | Response contains ledger ID                                      | contractId=<VALID_ID>    | Returns ledgerId                                                                               | Y                 |
+| 18      | Response contains staking info when applicable                   | contractId=<VALID_ID>    | Returns stakingInfo object with all sub-fields (if staked)                                    | Y                 |
 

--- a/src/tests/contract-service/test-contract-info-query.ts
+++ b/src/tests/contract-service/test-contract-info-query.ts
@@ -21,6 +21,8 @@ async function createTestContract(
   constructorMessage: string,
   privateKey?: string,
   memo?: string,
+  autoRenewAccountId?: string,
+  stakedNodeId?: string,
 ): Promise<{ contractId: string; adminKey: string; memo?: string }> {
   const ed25519PrivateKey = privateKey
     ? privateKey
@@ -64,6 +66,14 @@ async function createTestContract(
 
   if (memo) {
     createParams.memo = memo;
+  }
+
+  if (autoRenewAccountId) {
+    createParams.autoRenewAccountId = autoRenewAccountId;
+  }
+
+  if (stakedNodeId) {
+    createParams.stakedNodeId = stakedNodeId;
   }
 
   const response = await JSONRPCRequest(
@@ -122,6 +132,8 @@ describe("ContractInfoQuery", function () {
         "Hello from Hedera",
         undefined,
         "Test Contract Memo",
+        process.env.OPERATOR_ACCOUNT_ID as string,
+        "0",
       );
       contractId = contractData.contractId;
       adminKey = contractData.adminKey;
@@ -183,17 +195,16 @@ describe("ContractInfoQuery", function () {
     });
 
     it("(#6) Executes query and retrieves cost", async function () {
-      const response = await performContractInfoQuery(this, contractId);
+      const response = await JSONRPCRequest(this, "contractInfoQuery", {
+        contractId,
+        getCost: true,
+      });
 
       expect(response).to.not.be.null;
-      // Verify cost information if available in response
-      // eslint-disable-next-line eqeqeq
-      if (response.cost != null) {
-        expect(response.cost).to.be.a("string");
-        const cost = parseInt(response.cost);
-        expect(cost).to.be.a("number");
-        expect(cost).to.be.at.least(0);
-      }
+      expect(response.cost).to.be.a("string");
+      const cost = parseInt(response.cost);
+      expect(cost).to.be.a("number");
+      expect(cost).to.be.greaterThan(0);
     });
 
     it("(#7) Response contains contract ID and account ID", async function () {
@@ -284,26 +295,18 @@ describe("ContractInfoQuery", function () {
     it("(#15) Response contains contract account ID", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
-      // contractAccountId may be undefined or null
-      // eslint-disable-next-line eqeqeq
-      if (response.contractAccountId != null) {
-        expect(response.contractAccountId).to.be.a("string");
-        // Contract account ID is an EVM address (hex string)
-        expect(response.contractAccountId).to.match(/^[0-9a-fA-F]+$/);
-        expect(response.contractAccountId.length).to.be.greaterThan(0);
-      }
+      expect(response.contractAccountId).to.be.a("string");
+      // Contract account ID is an EVM address (hex string)
+      expect(response.contractAccountId).to.match(/^[0-9a-fA-F]+$/);
+      expect(response.contractAccountId.length).to.be.greaterThan(0);
     });
 
     it("(#16) Response contains auto-renew account ID", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
-      // autoRenewAccountId may be undefined or null
-      // eslint-disable-next-line eqeqeq
-      if (response.autoRenewAccountId != null) {
-        expect(response.autoRenewAccountId).to.be.a("string");
-        // Auto-renew account ID format: shard.realm.number
-        expect(response.autoRenewAccountId).to.match(/^\d+\.\d+\.\d+$/);
-      }
+      expect(response.autoRenewAccountId).to.be.a("string");
+      // Auto-renew account ID format: shard.realm.number
+      expect(response.autoRenewAccountId).to.match(/^\d+\.\d+\.\d+$/);
     });
 
     it("(#17) Response contains max automatic token associations", async function () {
@@ -329,64 +332,31 @@ describe("ContractInfoQuery", function () {
     it("(#19) Response contains staking info when applicable", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
-      // stakingInfo may be undefined or null
-      // eslint-disable-next-line eqeqeq
-      if (response.stakingInfo != null) {
-        expect(response.stakingInfo).to.be.an("object");
+      expect(response.stakingInfo).to.be.an("object");
 
-        // declineStakingReward should be a boolean if present
-        // eslint-disable-next-line eqeqeq
-        if (response.stakingInfo.declineStakingReward != null) {
-          expect(response.stakingInfo.declineStakingReward).to.be.a("boolean");
-        }
+      expect(response.stakingInfo.declineStakingReward).to.be.a("boolean");
 
-        // stakePeriodStart should be a string timestamp if present
-        // eslint-disable-next-line eqeqeq
-        if (response.stakingInfo.stakePeriodStart != null) {
-          expect(response.stakingInfo.stakePeriodStart).to.be.a("string");
-          const stakePeriodStart = parseInt(
-            response.stakingInfo.stakePeriodStart,
-          );
-          expect(stakePeriodStart).to.be.a("number");
-          expect(stakePeriodStart).to.be.at.least(0);
-        }
+      expect(response.stakingInfo.stakePeriodStart).to.be.a("string");
+      const stakePeriodStart = parseInt(response.stakingInfo.stakePeriodStart);
+      expect(stakePeriodStart).to.be.a("number");
+      expect(stakePeriodStart).to.be.at.least(0);
 
-        // pendingReward should be a string (tinybars) if present
-        // eslint-disable-next-line eqeqeq
-        if (response.stakingInfo.pendingReward != null) {
-          expect(response.stakingInfo.pendingReward).to.be.a("string");
-          const pendingReward = parseInt(response.stakingInfo.pendingReward);
-          expect(pendingReward).to.be.a("number");
-          expect(pendingReward).to.be.at.least(0);
-        }
+      expect(response.stakingInfo.pendingReward).to.be.a("string");
+      const pendingReward = parseInt(response.stakingInfo.pendingReward);
+      expect(pendingReward).to.be.a("number");
+      expect(pendingReward).to.be.at.least(0);
 
-        // stakedToMe should be a string (tinybars) if present
-        // eslint-disable-next-line eqeqeq
-        if (response.stakingInfo.stakedToMe != null) {
-          expect(response.stakingInfo.stakedToMe).to.be.a("string");
-          const stakedToMe = parseInt(response.stakingInfo.stakedToMe);
-          expect(stakedToMe).to.be.a("number");
-          expect(stakedToMe).to.be.at.least(0);
-        }
+      expect(response.stakingInfo.stakedToMe).to.be.a("string");
+      const stakedToMe = parseInt(response.stakingInfo.stakedToMe);
+      expect(stakedToMe).to.be.a("number");
+      expect(stakedToMe).to.be.at.least(0);
 
-        // stakedAccountId should be a string (account ID) if present
-        // eslint-disable-next-line eqeqeq
-        if (response.stakingInfo.stakedAccountId != null) {
-          expect(response.stakingInfo.stakedAccountId).to.be.a("string");
-          expect(response.stakingInfo.stakedAccountId).to.match(
-            /^\d+\.\d+\.\d+$/,
-          );
-        }
-
-        // stakedNodeId should be a string (node ID) if present
-        // eslint-disable-next-line eqeqeq
-        if (response.stakingInfo.stakedNodeId != null) {
-          expect(response.stakingInfo.stakedNodeId).to.be.a("string");
-          const stakedNodeId = parseInt(response.stakingInfo.stakedNodeId);
-          expect(stakedNodeId).to.be.a("number");
-          expect(stakedNodeId).to.be.at.least(0);
-        }
-      }
+      // Contract is staked to a node, so stakedNodeId should be present
+      // and stakedAccountId should not (they are mutually exclusive)
+      expect(response.stakingInfo.stakedNodeId).to.be.a("string");
+      const stakedNodeId = parseInt(response.stakingInfo.stakedNodeId);
+      expect(stakedNodeId).to.be.a("number");
+      expect(stakedNodeId).to.be.at.least(0);
     });
   });
 });

--- a/src/tests/contract-service/test-contract-info-query.ts
+++ b/src/tests/contract-service/test-contract-info-query.ts
@@ -187,7 +187,8 @@ describe("ContractInfoQuery", function () {
 
       expect(response).to.not.be.null;
       // Verify cost information if available in response
-      if (response.cost !== undefined) {
+      // eslint-disable-next-line eqeqeq
+      if (response.cost != null) {
         expect(response.cost).to.be.a("string");
         const cost = parseInt(response.cost);
         expect(cost).to.be.a("number");
@@ -283,8 +284,9 @@ describe("ContractInfoQuery", function () {
     it("(#15) Response contains contract account ID", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
-      // contractAccountId may be undefined or a string (EVM address format)
-      if (response.contractAccountId !== undefined) {
+      // contractAccountId may be undefined or null
+      // eslint-disable-next-line eqeqeq
+      if (response.contractAccountId != null) {
         expect(response.contractAccountId).to.be.a("string");
         // Contract account ID is an EVM address (hex string)
         expect(response.contractAccountId).to.match(/^[0-9a-fA-F]+$/);
@@ -295,8 +297,9 @@ describe("ContractInfoQuery", function () {
     it("(#16) Response contains auto-renew account ID", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
-      // autoRenewAccountId may be undefined or a string
-      if (response.autoRenewAccountId !== undefined) {
+      // autoRenewAccountId may be undefined or null
+      // eslint-disable-next-line eqeqeq
+      if (response.autoRenewAccountId != null) {
         expect(response.autoRenewAccountId).to.be.a("string");
         // Auto-renew account ID format: shard.realm.number
         expect(response.autoRenewAccountId).to.match(/^\d+\.\d+\.\d+$/);
@@ -326,17 +329,20 @@ describe("ContractInfoQuery", function () {
     it("(#19) Response contains staking info when applicable", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
-      // stakingInfo may be undefined if contract is not staked
-      if (response.stakingInfo !== undefined) {
+      // stakingInfo may be undefined or null
+      // eslint-disable-next-line eqeqeq
+      if (response.stakingInfo != null) {
         expect(response.stakingInfo).to.be.an("object");
 
         // declineStakingReward should be a boolean if present
-        if (response.stakingInfo.declineStakingReward !== undefined) {
+        // eslint-disable-next-line eqeqeq
+        if (response.stakingInfo.declineStakingReward != null) {
           expect(response.stakingInfo.declineStakingReward).to.be.a("boolean");
         }
 
         // stakePeriodStart should be a string timestamp if present
-        if (response.stakingInfo.stakePeriodStart !== undefined) {
+        // eslint-disable-next-line eqeqeq
+        if (response.stakingInfo.stakePeriodStart != null) {
           expect(response.stakingInfo.stakePeriodStart).to.be.a("string");
           const stakePeriodStart = parseInt(
             response.stakingInfo.stakePeriodStart,
@@ -346,7 +352,8 @@ describe("ContractInfoQuery", function () {
         }
 
         // pendingReward should be a string (tinybars) if present
-        if (response.stakingInfo.pendingReward !== undefined) {
+        // eslint-disable-next-line eqeqeq
+        if (response.stakingInfo.pendingReward != null) {
           expect(response.stakingInfo.pendingReward).to.be.a("string");
           const pendingReward = parseInt(response.stakingInfo.pendingReward);
           expect(pendingReward).to.be.a("number");
@@ -354,7 +361,8 @@ describe("ContractInfoQuery", function () {
         }
 
         // stakedToMe should be a string (tinybars) if present
-        if (response.stakingInfo.stakedToMe !== undefined) {
+        // eslint-disable-next-line eqeqeq
+        if (response.stakingInfo.stakedToMe != null) {
           expect(response.stakingInfo.stakedToMe).to.be.a("string");
           const stakedToMe = parseInt(response.stakingInfo.stakedToMe);
           expect(stakedToMe).to.be.a("number");
@@ -362,7 +370,8 @@ describe("ContractInfoQuery", function () {
         }
 
         // stakedAccountId should be a string (account ID) if present
-        if (response.stakingInfo.stakedAccountId !== undefined) {
+        // eslint-disable-next-line eqeqeq
+        if (response.stakingInfo.stakedAccountId != null) {
           expect(response.stakingInfo.stakedAccountId).to.be.a("string");
           expect(response.stakingInfo.stakedAccountId).to.match(
             /^\d+\.\d+\.\d+$/,
@@ -370,7 +379,8 @@ describe("ContractInfoQuery", function () {
         }
 
         // stakedNodeId should be a string (node ID) if present
-        if (response.stakingInfo.stakedNodeId !== undefined) {
+        // eslint-disable-next-line eqeqeq
+        if (response.stakingInfo.stakedNodeId != null) {
           expect(response.stakingInfo.stakedNodeId).to.be.a("string");
           const stakedNodeId = parseInt(response.stakingInfo.stakedNodeId);
           expect(stakedNodeId).to.be.a("number");

--- a/src/tests/contract-service/test-contract-info-query.ts
+++ b/src/tests/contract-service/test-contract-info-query.ts
@@ -194,20 +194,7 @@ describe("ContractInfoQuery", function () {
       expect(response.balance).to.not.be.null;
     });
 
-    it("(#6) Executes query and retrieves cost", async function () {
-      const response = await JSONRPCRequest(this, "contractInfoQuery", {
-        contractId,
-        getCost: true,
-      });
-
-      expect(response).to.not.be.null;
-      expect(response.cost).to.be.a("string");
-      const cost = parseInt(response.cost);
-      expect(cost).to.be.a("number");
-      expect(cost).to.be.greaterThan(0);
-    });
-
-    it("(#7) Response contains contract ID and account ID", async function () {
+    it("(#6) Response contains contract ID and account ID", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response).to.not.be.null;
@@ -220,7 +207,7 @@ describe("ContractInfoQuery", function () {
       expect(response.accountId).to.match(/^\d+\.\d+\.\d+$/);
     });
 
-    it("(#8) Response contains admin key matching the created contract", async function () {
+    it("(#7) Response contains admin key matching the created contract", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.adminKey).to.not.be.null;
@@ -228,7 +215,7 @@ describe("ContractInfoQuery", function () {
       expect(response.adminKey).to.equal(adminKey);
     });
 
-    it("(#9) Response contains expiration time in the future", async function () {
+    it("(#8) Response contains expiration time in the future", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.expirationTime).to.not.be.null;
@@ -242,7 +229,7 @@ describe("ContractInfoQuery", function () {
       expect(expirationTimestamp).to.be.greaterThan(now - 60); // Allow 60 seconds tolerance
     });
 
-    it("(#10) Response contains valid auto-renew period", async function () {
+    it("(#9) Response contains valid auto-renew period", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.autoRenewPeriod).to.not.be.null;
@@ -253,7 +240,7 @@ describe("ContractInfoQuery", function () {
       expect(autoRenewSeconds).to.be.greaterThan(0);
     });
 
-    it("(#11) Response contains contract balance as valid number", async function () {
+    it("(#10) Response contains contract balance as valid number", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.balance).to.not.be.null;
@@ -264,7 +251,7 @@ describe("ContractInfoQuery", function () {
       expect(balance).to.be.at.least(0); // Balance should be >= 0
     });
 
-    it("(#12) Response contains contract memo matching the created contract", async function () {
+    it("(#11) Response contains contract memo matching the created contract", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       // Contract memo should match what we set during creation
@@ -273,7 +260,7 @@ describe("ContractInfoQuery", function () {
       expect(response.contractMemo).to.equal(memo);
     });
 
-    it("(#13) Response contains isDeleted flag", async function () {
+    it("(#12) Response contains isDeleted flag", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.isDeleted).to.not.be.null;
@@ -281,7 +268,7 @@ describe("ContractInfoQuery", function () {
       expect(response.isDeleted).to.equal(false); // Contract should not be deleted
     });
 
-    it("(#14) Response contains storage information as valid number", async function () {
+    it("(#13) Response contains storage information as valid number", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.storage).to.not.be.null;
@@ -292,7 +279,7 @@ describe("ContractInfoQuery", function () {
       expect(storage).to.be.at.least(0); // Storage should be >= 0
     });
 
-    it("(#15) Response contains contract account ID", async function () {
+    it("(#14) Response contains contract account ID", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.contractAccountId).to.be.a("string");
@@ -301,7 +288,7 @@ describe("ContractInfoQuery", function () {
       expect(response.contractAccountId.length).to.be.greaterThan(0);
     });
 
-    it("(#16) Response contains auto-renew account ID", async function () {
+    it("(#15) Response contains auto-renew account ID", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.autoRenewAccountId).to.be.a("string");
@@ -309,7 +296,7 @@ describe("ContractInfoQuery", function () {
       expect(response.autoRenewAccountId).to.match(/^\d+\.\d+\.\d+$/);
     });
 
-    it("(#17) Response contains max automatic token associations", async function () {
+    it("(#16) Response contains max automatic token associations", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.maxAutomaticTokenAssociations).to.not.be.null;
@@ -320,7 +307,7 @@ describe("ContractInfoQuery", function () {
       expect(maxAssociations).to.be.at.least(0);
     });
 
-    it("(#18) Response contains ledger ID", async function () {
+    it("(#17) Response contains ledger ID", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.ledgerId).to.not.be.null;
@@ -329,7 +316,7 @@ describe("ContractInfoQuery", function () {
       expect(response.ledgerId.length).to.be.greaterThan(0);
     });
 
-    it("(#19) Response contains staking info when applicable", async function () {
+    it("(#18) Response contains staking info when applicable", async function () {
       const response = await performContractInfoQuery(this, contractId);
 
       expect(response.stakingInfo).to.be.an("object");


### PR DESCRIPTION
**Description**:
- Removed all if guards — tests now assert the raw response directly without silently skipping fields
- Set up contract creation with all optional fields populated — the before hook now creates the contract with autoRenewAccountId and stakedNodeId so the response always contains these fields
- Removed the cost test (`#6`) — cost is not part of the contractInfoQuery response; it requires a separate getCost API which is out of scope                                                                                                  

**Related issue(s)**:

Fixes #625

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
