### PR TITLE
feat: add daily CI workflow

### DIFF
--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - '.github/workflows/daily_compatibility.yml'
+      - ".github/workflows/daily_compatibility.yml"
   schedule:
-    - cron: '0 6 * * 1-5' # 06:00 UTC weekdays
+    - cron: "0 6 * * 1-5" # 06:00 UTC weekdays
   workflow_dispatch:
 
 concurrency:
@@ -74,7 +74,8 @@ jobs:
 
   # Summary and Slack notification
   summary-and-notify:
-    needs: [resolve-refs, js-compatibility, go-compatibility, java-compatibility]
+    needs:
+      [resolve-refs, js-compatibility, go-compatibility, java-compatibility]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -217,7 +218,7 @@ jobs:
       - name: Send Slack notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
-          webhook: "https://hooks.slack.com/services/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"
+          webhook: "https://hooks.slack.com/services/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"
           webhook-type: incoming-webhook
           payload-file-path: slack_payload.json
           errors: true

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - ".github/workflows/daily_compatibility.yml"
   schedule:
-    - cron: "0 10 * * 1-5" # 10:00 UTC weekdays
+    - cron: "0 6 * * 1-5" # 06:00 UTC weekdays
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -20,13 +20,18 @@ defaults:
 jobs:
   # Resolve HEAD SHAs for main branches
   resolve-refs:
-    runs-on: ubuntu-latest
+    runs-on: hiero-client-sdk-linux-large
     outputs:
       tck-sha: ${{ steps.refs.outputs.tck-sha }}
       js-sha: ${{ steps.refs.outputs.js-sha }}
       go-sha: ${{ steps.refs.outputs.go-sha }}
       java-sha: ${{ steps.refs.outputs.java-sha }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
       - name: Resolve main branch SHAs
         id: refs
         run: |
@@ -78,8 +83,13 @@ jobs:
     needs:
       [resolve-refs, js-compatibility, go-compatibility, java-compatibility]
     if: ${{ always() }}
-    runs-on: ubuntu-latest
+    runs-on: hiero-client-sdk-linux-large
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
       - name: Determine results
         id: results
         run: |

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -214,11 +214,10 @@ jobs:
           }
           EOF
 
-      # TODO: Replace hardcoded webhook with ${{ secrets.SLACK_TCK_DAILY_WEBHOOK }} before merging
       - name: Send Slack notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
-          webhook: "https://hooks.slack.com/services/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"
+          webhook: ${{ secrets.SLACK_TCK_DAILY_WEBHOOK }}
           webhook-type: incoming-webhook
           payload-file-path: slack_payload.json
           errors: true

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -51,28 +51,32 @@ jobs:
           echo "- Go SDK: \`$GO_SHA\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Java SDK: \`$JAVA_SHA\`" >> "$GITHUB_STEP_SUMMARY"
 
-  # TODO: Replace stubs with real sub-workflow calls after testing failure path
-  # Stub SDK jobs — JS fails intentionally to test failure Slack message
+  # Test JavaScript SDK
   js-compatibility:
     needs: resolve-refs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Simulate JS SDK failure
-        run: exit 1
+    uses: ./.github/workflows/js_compatibility.yml
+    with:
+      custom-job-name: "Daily JS SDK (main)"
+      js-sdk-version: main
+    secrets: inherit
 
+  # Test Go SDK
   go-compatibility:
     needs: resolve-refs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Stub Go SDK compatibility test
-        run: echo "Stub - Go SDK pass"
+    uses: ./.github/workflows/go_compatibility.yml
+    with:
+      custom-job-name: "Daily Go SDK (main)"
+      go-sdk-version: main
+    secrets: inherit
 
+  # Test Java SDK
   java-compatibility:
     needs: resolve-refs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Stub Java SDK compatibility test
-        run: echo "Stub - Java SDK pass"
+    uses: ./.github/workflows/java_compatibility.yml
+    with:
+      custom-job-name: "Daily Java SDK (main)"
+      java-sdk-version: main
+    secrets: inherit
 
   # Summary and Slack notification
   summary-and-notify:

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -5,6 +5,7 @@ permissions:
   contents: read
 
 on:
+  # TODO: Remove pull_request trigger before merging — only used for testing
   pull_request:
     branches: [main]
     paths:
@@ -50,27 +51,32 @@ jobs:
           echo "- Go SDK: \`$GO_SHA\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Java SDK: \`$JAVA_SHA\`" >> "$GITHUB_STEP_SUMMARY"
 
-  # Stub SDK jobs (Phase A — replace with real sub-workflow calls in Phase B)
+  # Test JavaScript SDK
   js-compatibility:
     needs: resolve-refs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Stub JS SDK compatibility test
-        run: echo "Stub - JS SDK compatibility test would run here against main"
+    uses: ./.github/workflows/js_compatibility.yml
+    with:
+      custom-job-name: "Daily JS SDK (main)"
+      js-sdk-version: main
+    secrets: inherit
 
+  # Test Go SDK
   go-compatibility:
     needs: resolve-refs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Stub Go SDK compatibility test
-        run: echo "Stub - Go SDK compatibility test would run here against main"
+    uses: ./.github/workflows/go_compatibility.yml
+    with:
+      custom-job-name: "Daily Go SDK (main)"
+      go-sdk-version: main
+    secrets: inherit
 
+  # Test Java SDK
   java-compatibility:
     needs: resolve-refs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Stub Java SDK compatibility test
-        run: echo "Stub - Java SDK compatibility test would run here against main"
+    uses: ./.github/workflows/java_compatibility.yml
+    with:
+      custom-job-name: "Daily Java SDK (main)"
+      java-sdk-version: main
+    secrets: inherit
 
   # Summary and Slack notification
   summary-and-notify:
@@ -156,7 +162,7 @@ jobs:
                     "fields": [
                       {
                         "type": "mrkdwn",
-                        "text": "*JS SDK* (\`${{ needs.resolve-refs.outputs.js-sha }}\`)"
+                        "text": "*JS SDK* (<https://github.com/hiero-ledger/hiero-sdk-js/commit/${{ needs.resolve-refs.outputs.js-sha }}|${{ needs.resolve-refs.outputs.js-sha }}>)"
                       },
                       {
                         "type": "mrkdwn",
@@ -164,7 +170,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Go SDK* (\`${{ needs.resolve-refs.outputs.go-sha }}\`)"
+                        "text": "*Go SDK* (<https://github.com/hiero-ledger/hiero-sdk-go/commit/${{ needs.resolve-refs.outputs.go-sha }}|${{ needs.resolve-refs.outputs.go-sha }}>)"
                       },
                       {
                         "type": "mrkdwn",
@@ -172,7 +178,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "*Java SDK* (\`${{ needs.resolve-refs.outputs.java-sha }}\`)"
+                        "text": "*Java SDK* (<https://github.com/hiero-ledger/hiero-sdk-java/commit/${{ needs.resolve-refs.outputs.java-sha }}|${{ needs.resolve-refs.outputs.java-sha }}>)"
                       },
                       {
                         "type": "mrkdwn",
@@ -196,7 +202,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "\`${{ needs.resolve-refs.outputs.tck-sha }}\`"
+                        "text": "<https://github.com/hiero-ledger/hiero-sdk-tck/commit/${{ needs.resolve-refs.outputs.tck-sha }}|${{ needs.resolve-refs.outputs.tck-sha }}>"
                       },
                       {
                         "type": "mrkdwn",

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -5,11 +5,6 @@ permissions:
   contents: read
 
 on:
-  # TODO: Remove pull_request trigger before merging — only used for testing
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/workflows/daily_compatibility.yml"
   schedule:
     - cron: "0 6 * * 1-5" # 06:00 UTC weekdays
   workflow_dispatch:

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - ".github/workflows/daily_compatibility.yml"
   schedule:
-    - cron: "0 6 * * 1-5" # 06:00 UTC weekdays
+    - cron: "0 10 * * 1-5"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -11,7 +11,7 @@ on:
     paths:
       - ".github/workflows/daily_compatibility.yml"
   schedule:
-    - cron: "0 10 * * 1-5"
+    - cron: "0 10 * * 1-5" # 10:00 UTC weekdays
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -217,9 +217,9 @@ jobs:
       - name: Send Slack notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
-          webhook: "https://hooks.slack.com/services/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"
-          webhook-type: incoming-webhook
-          payload-templated: true
+          method: webhook
+          webhook-url: "https://hooks.slack.com/services/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"
+          errors: true
           payload-file-path: slack_payload.json
 
       - name: Write GitHub Step Summary

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -5,6 +5,10 @@ permissions:
   contents: read
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/daily_compatibility.yml'
   schedule:
     - cron: '0 6 * * 1-5' # 06:00 UTC weekdays
   workflow_dispatch:

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -51,32 +51,28 @@ jobs:
           echo "- Go SDK: \`$GO_SHA\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Java SDK: \`$JAVA_SHA\`" >> "$GITHUB_STEP_SUMMARY"
 
-  # Test JavaScript SDK
+  # TODO: Replace stubs with real sub-workflow calls after testing failure path
+  # Stub SDK jobs — JS fails intentionally to test failure Slack message
   js-compatibility:
     needs: resolve-refs
-    uses: ./.github/workflows/js_compatibility.yml
-    with:
-      custom-job-name: "Daily JS SDK (main)"
-      js-sdk-version: main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Simulate JS SDK failure
+        run: exit 1
 
-  # Test Go SDK
   go-compatibility:
     needs: resolve-refs
-    uses: ./.github/workflows/go_compatibility.yml
-    with:
-      custom-job-name: "Daily Go SDK (main)"
-      go-sdk-version: main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stub Go SDK compatibility test
+        run: echo "Stub - Go SDK pass"
 
-  # Test Java SDK
   java-compatibility:
     needs: resolve-refs
-    uses: ./.github/workflows/java_compatibility.yml
-    with:
-      custom-job-name: "Daily Java SDK (main)"
-      java-sdk-version: main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stub Java SDK compatibility test
+        run: echo "Stub - Java SDK pass"
 
   # Summary and Slack notification
   summary-and-notify:

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -1,0 +1,246 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "Daily TCK Compatibility Check"
+
+permissions:
+  contents: read
+
+on:
+  schedule:
+    - cron: '0 6 * * 1-5' # 06:00 UTC weekdays
+  workflow_dispatch:
+
+concurrency:
+  group: daily-tck-compatibility
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Resolve HEAD SHAs for main branches
+  resolve-refs:
+    runs-on: ubuntu-latest
+    outputs:
+      tck-sha: ${{ steps.refs.outputs.tck-sha }}
+      js-sha: ${{ steps.refs.outputs.js-sha }}
+      go-sha: ${{ steps.refs.outputs.go-sha }}
+      java-sha: ${{ steps.refs.outputs.java-sha }}
+    steps:
+      - name: Resolve main branch SHAs
+        id: refs
+        run: |
+          TCK_SHA=$(git ls-remote https://github.com/hiero-ledger/hiero-sdk-tck refs/heads/main | cut -c1-7)
+          JS_SHA=$(git ls-remote https://github.com/hiero-ledger/hiero-sdk-js refs/heads/main | cut -c1-7)
+          GO_SHA=$(git ls-remote https://github.com/hiero-ledger/hiero-sdk-go refs/heads/main | cut -c1-7)
+          JAVA_SHA=$(git ls-remote https://github.com/hiero-ledger/hiero-sdk-java refs/heads/main | cut -c1-7)
+
+          echo "tck-sha=$TCK_SHA" >> "$GITHUB_OUTPUT"
+          echo "js-sha=$JS_SHA" >> "$GITHUB_OUTPUT"
+          echo "go-sha=$GO_SHA" >> "$GITHUB_OUTPUT"
+          echo "java-sha=$JAVA_SHA" >> "$GITHUB_OUTPUT"
+
+          echo "### Resolved SHAs" >> "$GITHUB_STEP_SUMMARY"
+          echo "- TCK: \`$TCK_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- JS SDK: \`$JS_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Go SDK: \`$GO_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Java SDK: \`$JAVA_SHA\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # Stub SDK jobs (Phase A — replace with real sub-workflow calls in Phase B)
+  js-compatibility:
+    needs: resolve-refs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stub JS SDK compatibility test
+        run: echo "Stub - JS SDK compatibility test would run here against main"
+
+  go-compatibility:
+    needs: resolve-refs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stub Go SDK compatibility test
+        run: echo "Stub - Go SDK compatibility test would run here against main"
+
+  java-compatibility:
+    needs: resolve-refs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stub Java SDK compatibility test
+        run: echo "Stub - Java SDK compatibility test would run here against main"
+
+  # Summary and Slack notification
+  summary-and-notify:
+    needs: [resolve-refs, js-compatibility, go-compatibility, java-compatibility]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine results
+        id: results
+        run: |
+          # Per-SDK status
+          if [[ "${{ needs.js-compatibility.result }}" == "success" ]]; then
+            echo "js-status=:white_check_mark: PASSED" >> "$GITHUB_OUTPUT"
+            echo "js-result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "js-status=:x: FAILED" >> "$GITHUB_OUTPUT"
+            echo "js-result=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "${{ needs.go-compatibility.result }}" == "success" ]]; then
+            echo "go-status=:white_check_mark: PASSED" >> "$GITHUB_OUTPUT"
+            echo "go-result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "go-status=:x: FAILED" >> "$GITHUB_OUTPUT"
+            echo "go-result=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "${{ needs.java-compatibility.result }}" == "success" ]]; then
+            echo "java-status=:white_check_mark: PASSED" >> "$GITHUB_OUTPUT"
+            echo "java-result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "java-status=:x: FAILED" >> "$GITHUB_OUTPUT"
+            echo "java-result=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Overall status
+          if [[ "${{ needs.js-compatibility.result }}" == "success" ]] && \
+             [[ "${{ needs.go-compatibility.result }}" == "success" ]] && \
+             [[ "${{ needs.java-compatibility.result }}" == "success" ]]; then
+            echo "overall=PASSED" >> "$GITHUB_OUTPUT"
+            echo "color=#36a64f" >> "$GITHUB_OUTPUT"
+            echo "emoji=:white_check_mark:" >> "$GITHUB_OUTPUT"
+          else
+            echo "overall=FAILED" >> "$GITHUB_OUTPUT"
+            echo "color=#FF0000" >> "$GITHUB_OUTPUT"
+            echo "emoji=:x:" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Slack payload
+        id: payload
+        run: |
+          cat <<EOF > slack_payload.json
+          {
+            "attachments": [
+              {
+                "color": "${{ steps.results.outputs.color }}",
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":test_tube: TCK Daily Compatibility Report",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "divider"
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*Overall: ${{ steps.results.outputs.emoji }} ${{ steps.results.outputs.overall }}*"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*SDK Compatibility Results*"
+                    },
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*JS SDK* (\`${{ needs.resolve-refs.outputs.js-sha }}\`)"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "${{ steps.results.outputs.js-status }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Go SDK* (\`${{ needs.resolve-refs.outputs.go-sha }}\`)"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "${{ steps.results.outputs.go-status }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Java SDK* (\`${{ needs.resolve-refs.outputs.java-sha }}\`)"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "${{ steps.results.outputs.java-status }}"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "divider"
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*Workflow & Commit Information*"
+                    },
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*TCK Commit*:"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "\`${{ needs.resolve-refs.outputs.tck-sha }}\`"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Workflow Run*:"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+
+      # TODO: Replace hardcoded webhook with ${{ secrets.SLACK_TCK_DAILY_WEBHOOK }} before merging
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: "https://hooks.slack.com/services/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"
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json
+
+      - name: Write GitHub Step Summary
+        run: |
+          echo "## Daily Compatibility Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "${{ steps.results.outputs.js-result }}" == "success" ]]; then
+            echo ":white_check_mark: **JS SDK**: PASSED" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo ":x: **JS SDK**: FAILED" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [[ "${{ steps.results.outputs.go-result }}" == "success" ]]; then
+            echo ":white_check_mark: **Go SDK**: PASSED" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo ":x: **Go SDK**: FAILED" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          if [[ "${{ steps.results.outputs.java-result }}" == "success" ]]; then
+            echo ":white_check_mark: **Java SDK**: PASSED" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo ":x: **Java SDK**: FAILED" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Fail if any SDK failed
+        if: ${{ steps.results.outputs.overall == 'FAILED' }}
+        run: exit 1

--- a/.github/workflows/daily_compatibility.yml
+++ b/.github/workflows/daily_compatibility.yml
@@ -217,10 +217,10 @@ jobs:
       - name: Send Slack notification
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
-          method: webhook
-          webhook-url: "https://hooks.slack.com/services/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"
-          errors: true
+          webhook: "https://hooks.slack.com/services/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"
+          webhook-type: incoming-webhook
           payload-file-path: slack_payload.json
+          errors: true
 
       - name: Write GitHub Step Summary
         run: |


### PR DESCRIPTION
**Description**:

  Add a daily CI workflow that automatically runs TCK compatibility tests against the main branches of all three Hiero SDKs (JavaScript, Go, Java) on weekdays at 06:00 UTC. The workflow resolves the latest commit SHAs from each SDK repository, runs the existing compatibility test workflows for each SDK in parallel, and sends a summary report to Slack with per-SDK pass/fail results and commit links. It also supports manual triggering via workflow_dispatch.                             
                                                                                                                          
  - Add .github/workflows/daily_compatibility.yml scheduled cron workflow                                                   
  - Resolve HEAD SHAs for TCK, JS SDK, Go SDK, and Java SDK main branches
  - Reuse existing js_compatibility.yml, go_compatibility.yml, and java_compatibility.yml reusable workflows                                              
  - Write GitHub Step Summary with per-SDK pass/fail status                                                                 
  - Use a repository secret SLACK_TCK_DAILY_WEBHOOK                               
  - Configure concurrency to prevent overlapping runs                                                                       
                                                       

**Related issue(s)**:

Fixes #629 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
