### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0",
+  "version": "0.11.0",
   "dependencies": {
     "@hashgraph/sdk": "^2.73.1",
     "axios": "^1.11.0",


### PR DESCRIPTION
## Summary

Bumps `package.json` version from `0.8.0` to `0.11.0` to align with the upcoming `v0.11.0` release tag.

## Context

Versions `0.9.0` and `0.10.0` were tagged without bumping `package.json`, so the field had drifted. This catches it up in one step alongside the `v0.11.0` release.

## Test plan

- [x] CI passes