### PR TITLE
feat: add HIP-1313 high-volume tests to AccountCreateTransaction

### DIFF
--- a/docs/test-specifications/common/CommonTransactionParameters.md
+++ b/docs/test-specifications/common/CommonTransactionParameters.md
@@ -17,6 +17,7 @@ There are common parameters that can be set for all Hiero transaction types. Thi
 | memo                     | string       | optional          |                                                                                                                                    |
 | regenerateTransactionId  | bool         | optional          |                                                                                                                                    |
 | signers                  | list<string> | optional          | List of DER-encoded hex strings of all additional private keys required to sign.                                                   |
+| highVolume               | bool         | optional          | HIP-1313 opt-in: route the transaction through the high-volume entity creation throttle bucket and variable-rate pricing. Default: unset (standard throttles). |
 
 ## Example Usage
 

--- a/docs/test-specifications/crypto-service/AccountCreateTransaction.md
+++ b/docs/test-specifications/crypto-service/AccountCreateTransaction.md
@@ -440,3 +440,45 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 }
 ```
 
+### **High Volume (HIP-1313):**
+
+- Opt-in flag (`commonTransactionParams.highVolume`) that routes the transaction through the high-volume entity creation throttle bucket and variable-rate pricing (HIP-1313). When omitted or `false`, the transaction uses the standard throttles and pricing.
+
+| Test no | Name                                                                            | Input                                                                          | Expected response                                                                                                  | Implemented (Y/N) |
+| ------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ----------------- |
+| 1       | Creates an account with `commonTransactionParams.highVolume=true`               | key=<VALID_KEY>, commonTransactionParams.highVolume=true                       | The account creation succeeds and the account is created via the high-volume throttle bucket.                       | Y                 |
+| 2       | Creates an account with `commonTransactionParams.highVolume=false`              | key=<VALID_KEY>, commonTransactionParams.highVolume=false                      | The account creation succeeds via the standard throttle bucket (default behaviour, regression guard).               | Y                 |
+| 3       | Omitting `highVolume` behaves identically to `false`                            | key=<VALID_KEY>, no `highVolume` field                                          | The account creation succeeds with the same throttle/fee treatment as `highVolume=false`.                            | Y                 |
+| 4       | `highVolume=true` with a sufficient `maxTransactionFee`                          | key=<VALID_KEY>, commonTransactionParams.highVolume=true, maxTransactionFee=10 hbar | The account creation succeeds and the actual transaction fee charged is `<= maxTransactionFee`.                      | Y                 |
+| 5       | `highVolume=true` with an insufficient `maxTransactionFee`                      | key=<VALID_KEY>, commonTransactionParams.highVolume=true, maxTransactionFee=1 tinybar | The account creation fails with `INSUFFICIENT_TX_FEE`.                                                              | Y                 |
+| 6       | Fee with `highVolume=true` differs from fee with `highVolume=false`             | Same account params executed twice, once per `highVolume` value                | The two transaction fees differ (high-volume pricing curve applied).                                                | N                 |
+
+#### JSON Request Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 99232,
+  "method": "createAccount",
+  "params": {
+    "key": "302a300506032b6570032100e9a0f9c81b3a2bb81a4af5fe05657aa849a3b9b0705da1fb52f331f42cf4b496",
+    "commonTransactionParams": {
+      "highVolume": true
+    }
+  }
+}
+```
+
+#### JSON Response Example
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 99232,
+  "result": {
+    "accountId": "0.0.12345",
+    "status": "SUCCESS"
+  }
+}
+```
+

--- a/src/tests/crypto-service/test-account-create-transaction.ts
+++ b/src/tests/crypto-service/test-account-create-transaction.ts
@@ -1001,7 +1001,7 @@ describe("AccountCreateTransaction", function () {
     };
 
     it("(#1) Creates an account with commonTransactionParams.highVolume=true", async function () {
-      const key = await generateEd25519PublicKey(this);
+      const key = await generateEd25519PrivateKey(this);
 
       const response = await JSONRPCRequest(this, "createAccount", {
         key,
@@ -1014,7 +1014,7 @@ describe("AccountCreateTransaction", function () {
     });
 
     it("(#2) Creates an account with commonTransactionParams.highVolume=false", async function () {
-      const key = await generateEd25519PublicKey(this);
+      const key = await generateEd25519PrivateKey(this);
 
       const response = await JSONRPCRequest(this, "createAccount", {
         key,
@@ -1027,7 +1027,7 @@ describe("AccountCreateTransaction", function () {
     });
 
     it("(#3) Omitting highVolume behaves identically to false", async function () {
-      const key = await generateEd25519PublicKey(this);
+      const key = await generateEd25519PrivateKey(this);
 
       const response = await JSONRPCRequest(this, "createAccount", {
         key,
@@ -1037,7 +1037,7 @@ describe("AccountCreateTransaction", function () {
     });
 
     it("(#4) highVolume=true with a sufficient maxTransactionFee", async function () {
-      const key = await generateEd25519PublicKey(this);
+      const key = await generateEd25519PrivateKey(this);
 
       const response = await JSONRPCRequest(this, "createAccount", {
         key,
@@ -1053,7 +1053,20 @@ describe("AccountCreateTransaction", function () {
     });
 
     it("(#5) highVolume=true with an insufficient maxTransactionFee", async function () {
-      const key = await generateEd25519PublicKey(this);
+      // Use a freshly-created non-treasury payer so fee enforcement applies
+      // deterministically. Some CI workflows hardcode the operator to the
+      // genesis treasury (0.0.2), which is exempt from fee checks; that
+      // exemption would mask INSUFFICIENT_TX_FEE if we paid from the operator.
+      const payerKey = await generateEd25519PrivateKey(this);
+      const payerResponse = await JSONRPCRequest(this, "createAccount", {
+        key: payerKey,
+        // 10 hbar -- plenty for a base AccountCreate fee, but small enough
+        // that we don't tie up operator balance unnecessarily.
+        initialBalance: "1000000000",
+      });
+      const payerId = payerResponse.accountId;
+
+      const key = await generateEd25519PrivateKey(this);
 
       try {
         await JSONRPCRequest(this, "createAccount", {
@@ -1061,6 +1074,8 @@ describe("AccountCreateTransaction", function () {
           commonTransactionParams: {
             highVolume: true,
             maxTransactionFee: 1,
+            transactionId: payerId,
+            signers: [payerKey],
           },
         });
       } catch (err: any) {

--- a/src/tests/crypto-service/test-account-create-transaction.ts
+++ b/src/tests/crypto-service/test-account-create-transaction.ts
@@ -992,5 +992,85 @@ describe("AccountCreateTransaction", function () {
     });
   });
 
+  describe("High Volume (HIP-1313)", async function () {
+    const verifyAccountCreated = async (accountId: string) => {
+      expect((await consensusInfoClient.getAccountInfo(accountId)).isDeleted).to
+        .be.false;
+      expect((await mirrorNodeClient.getAccountData(accountId)).deleted).to.be
+        .false;
+    };
+
+    it("(#1) Creates an account with commonTransactionParams.highVolume=true", async function () {
+      const key = await generateEd25519PublicKey(this);
+
+      const response = await JSONRPCRequest(this, "createAccount", {
+        key,
+        commonTransactionParams: {
+          highVolume: true,
+        },
+      });
+
+      await verifyAccountCreated(response.accountId);
+    });
+
+    it("(#2) Creates an account with commonTransactionParams.highVolume=false", async function () {
+      const key = await generateEd25519PublicKey(this);
+
+      const response = await JSONRPCRequest(this, "createAccount", {
+        key,
+        commonTransactionParams: {
+          highVolume: false,
+        },
+      });
+
+      await verifyAccountCreated(response.accountId);
+    });
+
+    it("(#3) Omitting highVolume behaves identically to false", async function () {
+      const key = await generateEd25519PublicKey(this);
+
+      const response = await JSONRPCRequest(this, "createAccount", {
+        key,
+      });
+
+      await verifyAccountCreated(response.accountId);
+    });
+
+    it("(#4) highVolume=true with a sufficient maxTransactionFee", async function () {
+      const key = await generateEd25519PublicKey(this);
+
+      const response = await JSONRPCRequest(this, "createAccount", {
+        key,
+        commonTransactionParams: {
+          highVolume: true,
+          // 10 hbar in tinybars; comfortably above the standard or
+          // high-volume-multiplied AccountCreate fee on local + mainnet.
+          maxTransactionFee: 1000000000,
+        },
+      });
+
+      await verifyAccountCreated(response.accountId);
+    });
+
+    it("(#5) highVolume=true with an insufficient maxTransactionFee", async function () {
+      const key = await generateEd25519PublicKey(this);
+
+      try {
+        await JSONRPCRequest(this, "createAccount", {
+          key,
+          commonTransactionParams: {
+            highVolume: true,
+            maxTransactionFee: 1,
+          },
+        });
+      } catch (err: any) {
+        assert.equal(err.data.status, "INSUFFICIENT_TX_FEE");
+        return;
+      }
+
+      assert.fail("Should throw an INSUFFICIENT_TX_FEE error");
+    });
+  });
+
   return Promise.resolve();
 });


### PR DESCRIPTION
## Summary
Adds the HIP-1313 high-volume entity creation tests to `AccountCreateTransaction`.

- Documents `commonTransactionParams.highVolume` in `CommonTransactionParameters.md`.
- Adds a `High Volume (HIP-1313)` property section to the `AccountCreateTransaction` spec with the test table.
- Adds a matching `describe` block in `test-account-create-transaction.ts` with 5 scenarios:
  - `highVolume=true` → account created
  - `highVolume=false` → account created (regression guard)
  - `highVolume` omitted → identical to `false`
  - `highVolume=true` + sufficient `maxTransactionFee` → success
  - `highVolume=true` + insufficient `maxTransactionFee` → `INSUFFICIENT_TX_FEE`

Backing JSON-RPC wiring in the JS SDK TCK server: https://github.com/hiero-ledger/hiero-sdk-js/pull/4089.

## Out of scope
Test #6 (fee differential between `highVolume=true` vs `false`) is marked **not implemented** in the spec. It requires reading the actual transaction fee via a `getTransactionRecord` JSON-RPC method the TCK does not yet expose. Splitting that into a follow-up keeps this PR focused.

## Known blocker
Some scenarios may not exercise the new code path on a freshly-started Solo if the network has not yet configured the high-volume throttle bucket / variable-rate pricing curves. The spec-compliance signal (#1-#3) should still pass because the flag is body-only; #4-#5 depend on the network honoring high-volume pricing. Same intent-vs-environment tradeoff as the HIP-1261 PR.

## Test plan
- [ ] `npm run test:serial` against a Solo / mirror with HIP-1313 buckets configured
- [ ] All 5 `it()` blocks in the new `High Volume (HIP-1313)` describe pass

Closes #648
