### PR TITLE
chore: add CODEOWNERS referencing shared SDK teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Default code owners for entire repository
+*                                               @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers
+
+#########################
+#####  Core Files  ######
+#########################
+
+# NOTE: Must be placed last to ensure enforcement over all other rules
+
+# Protection Rules for Github Configuration Files and Actions Workflows
+/.github/                                       @hiero-ledger/github-maintainers
+/.github/workflows/                             @hiero-ledger/github-maintainers
+
+# Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
+/CODEOWNERS                                     @hiero-ledger/github-maintainers
+
+# Protect the repository root files
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/hiero-sdk-committers @hiero-ledger/tsc
+**/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-sdk-maintainers @hiero-ledger/tsc


### PR DESCRIPTION
## What
Adds `.github/CODEOWNERS` (none existed before) so the repo is owned by the shared SDK teams after the team merge.

`@hiero-ledger/github-maintainers` and `@hiero-ledger/tsc` are intentionally left unchanged — they are not part of the SDK team merge.

## ⚠️ DO NOT MERGE YET
The shared teams `hiero-sdk-maintainers` / `hiero-sdk-committers` **do not exist yet**. Per the guide (§4) a CODEOWNERS team only takes effect once it exists and has write access in `governance/config.yaml`. This PR must land **together** with the governance PR that creates and grants those teams (§7) — merging it earlier would point `*` at a non-existent team and break code-owner enforcement.

Reference: https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/guides/sdk-team-structure-and-codeowners.md
