### PR TITLE
fix: align pauseStatus type between TokenInfoQuery spec and tests

### DIFF
--- a/docs/test-specifications/token-service/TokenInfoQuery.md
+++ b/docs/test-specifications/token-service/TokenInfoQuery.md
@@ -64,7 +64,7 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 | metadataKey          | string  | The metadata key of the token (if set).                                 |
 | defaultFreezeStatus  | boolean | The default freeze status for token accounts (if freeze key is set).    |
 | defaultKycStatus     | boolean | The default KYC status for token accounts (if KYC key is set).          |
-| pauseStatus          | string  | The pause status of the token (PAUSED/UNPAUSED/NOT_APPLICABLE).        |
+| pauseStatus          | boolean | The pause status of the token (true/false, null if no pause key).       |
 | isDeleted            | boolean | Whether the token has been deleted.                                     |
 | autoRenewAccountId   | string  | The account ID that pays for auto-renewal.                              |
 | autoRenewPeriod      | string  | The auto-renewal period in seconds.                                     |
@@ -129,9 +129,9 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 | 42      | Verify defaultFreezeStatus when no freezeKey       | Token without freezeKey                   | Returns null or false for defaultFreezeStatus                                 | N                 |
 | 43      | Verify defaultKycStatus when kycKey set            | Token with kycKey, defaultKycStatus=true  | Returns the correct default KYC status                                        | N                 |
 | 44      | Verify defaultKycStatus when no kycKey             | Token without kycKey                      | Returns null or false for defaultKycStatus                                    | N                 |
-| 45      | Verify pauseStatus for paused token                | Token that has been paused                | Returns PAUSED for pauseStatus                                                | N                 |
-| 46      | Verify pauseStatus for unpaused token              | Token with pauseKey but not paused        | Returns UNPAUSED for pauseStatus                                              | N                 |
-| 47      | Verify pauseStatus when no pauseKey                | Token without pauseKey                    | Returns NOT_APPLICABLE or null for pauseStatus                                | N                 |
+| 45      | Verify pauseStatus for paused token                | Token that has been paused                | Returns true for pauseStatus                                                  | N                 |
+| 46      | Verify pauseStatus for unpaused token              | Token with pauseKey but not paused        | Returns false for pauseStatus                                                 | N                 |
+| 47      | Verify pauseStatus when no pauseKey                | Token without pauseKey                    | Returns null for pauseStatus                                                  | N                 |
 | 48      | Verify isDeleted field for active token            | Active token                              | Returns false for isDeleted                                                   | N                 |
 | 49      | Verify customFees field with no fees               | Token without custom fees                 | Returns an empty array for customFees                                         | N                 |
 | 50      | Verify customFees field with fixed fee             | Token with fixed fee                      | Returns the correct fixed fee in customFees array                             | N                 |

--- a/src/tests/token-service/test-token-info-query.ts
+++ b/src/tests/token-service/test-token-info-query.ts
@@ -1066,11 +1066,13 @@ describe("TokenInfoQuery", function () {
         tokenId: tokenId,
       });
 
-      expect(response.pauseStatus.toString()).to.equal("true");
+      // The JS SDK TCK server returns pauseStatus as a stringified boolean,
+      // so accept both until it conforms to the boolean spec.
+      expect(response.pauseStatus).to.be.oneOf([true, "true"]);
 
       // Verify against consensus node
       const consensusInfo = await consensusInfoClient.getTokenInfo(tokenId);
-      expect(consensusInfo.pauseStatus?.toString()).to.equal("true");
+      expect(consensusInfo.pauseStatus).to.be.true;
     });
 
     it("(#46) Verify pauseStatus for unpaused token", async function () {
@@ -1090,11 +1092,13 @@ describe("TokenInfoQuery", function () {
         tokenId: tokenId,
       });
 
-      expect(response.pauseStatus.toString()).to.equal("false");
+      // The JS SDK TCK server returns pauseStatus as a stringified boolean,
+      // so accept both until it conforms to the boolean spec.
+      expect(response.pauseStatus).to.be.oneOf([false, "false"]);
 
       // Verify against consensus node
       const consensusInfo = await consensusInfoClient.getTokenInfo(tokenId);
-      expect(consensusInfo.pauseStatus?.toString()).to.equal("false");
+      expect(consensusInfo.pauseStatus).to.be.false;
     });
 
     it("(#47) Verify pauseStatus when no pauseKey", async function () {
@@ -1181,9 +1185,9 @@ describe("TokenInfoQuery", function () {
       expect(response.customFees).to.be.an("array");
       expect(response.customFees).to.have.lengthOf(1);
       expect(response.customFees[0]).to.have.property("feeCollectorAccountId");
-      expect(`${response.customFees[0].feeCollectorAccountId.realm}.${response.customFees[0].feeCollectorAccountId.shard}.${response.customFees[0].feeCollectorAccountId.num}`).to.equal(
-        feeCollectorAccountId,
-      );
+      expect(
+        `${response.customFees[0].feeCollectorAccountId.realm}.${response.customFees[0].feeCollectorAccountId.shard}.${response.customFees[0].feeCollectorAccountId.num}`,
+      ).to.equal(feeCollectorAccountId);
 
       // Verify against consensus node
       const consensusInfo = await consensusInfoClient.getTokenInfo(tokenId);
@@ -1224,9 +1228,9 @@ describe("TokenInfoQuery", function () {
       expect(response.customFees).to.be.an("array");
       expect(response.customFees).to.have.lengthOf(1);
       expect(response.customFees[0]).to.have.property("feeCollectorAccountId");
-      expect(`${response.customFees[0].feeCollectorAccountId.realm}.${response.customFees[0].feeCollectorAccountId.shard}.${response.customFees[0].feeCollectorAccountId.num}`).to.equal(
-        feeCollectorAccountId,
-      );
+      expect(
+        `${response.customFees[0].feeCollectorAccountId.realm}.${response.customFees[0].feeCollectorAccountId.shard}.${response.customFees[0].feeCollectorAccountId.num}`,
+      ).to.equal(feeCollectorAccountId);
 
       // Verify against consensus node
       const consensusInfo = await consensusInfoClient.getTokenInfo(tokenId);


### PR DESCRIPTION
## Description

Fixes a type mismatch between the TCK API specification and the tests for the `pauseStatus` field returned by `getTokenInfo`.

The spec documented `pauseStatus` as a string enum (`PAUSED`/`UNPAUSED`/`NOT_APPLICABLE`), but no SDK TCK server implements that: the underlying SDKs model it as a nullable boolean (the Java server returns `true`/`false`/`null`, the JS server returns the stringified `"true"`/`"false"`/`null`), and the tests already assert boolean-ish values.

Changes:
- **Spec** (`TokenInfoQuery.md`): `pauseStatus` is now documented as `boolean` (`true` if paused, `false` if unpaused, `null` if the token has no pause key), consistent with the sibling `defaultFreezeStatus`/`defaultKycStatus` fields. Test rows 45–47 updated accordingly.
- **Tests** (`test-token-info-query.ts`): the JSON-RPC response assertions now use `to.be.oneOf([true, "true"])` (explicitly tolerant of the JS server's stringified boolean until it conforms to the spec), and the consensus-node assertions are strict booleans, matching the style used in `test-token-pause-transaction.ts`. Also includes a prettier formatting fix for two `customFees` assertions so ESLint passes.

Follow-up (out of scope): the JS SDK TCK server (`tck/utils/helpers/token.ts` in hiero-sdk-js) should return the boolean directly instead of stringifying it, after which the response assertions can be tightened to plain `to.be.true`/`to.be.false`.

Fixes #655

## Related issue(s)

#655