### PR TITLE
feat: preflight endpoint checks and component version stamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "unified": "11.0.5"
   },
   "scripts": {
-    "test": "rm -rf mochawesome-report && mocha --parallel --jobs 7 --node-option require=ts-node/register --node-option require=tsconfig-paths/register --recursive 'src/tests/**/*.ts' --reporter mochawesome --exit; node scripts/check-test-results.mjs",
-    "test:file": "mocha --require ts-node/register --require tsconfig-paths/register --reporter mochawesome --exit",
+    "test": "rm -rf mochawesome-report && mocha --parallel --jobs 7 --node-option require=ts-node/register --node-option require=tsconfig-paths/register --require src/preflight.ts --recursive 'src/tests/**/*.ts' --reporter mochawesome --exit; node scripts/check-test-results.mjs",
+    "test:file": "mocha --require ts-node/register --require tsconfig-paths/register --require src/preflight.ts --reporter mochawesome --exit",
     "generate-mirror-node-models": "npx openapi-typescript-codegen --input mirror-node.yaml --output src/utils/models/mirror-node-models",
     "format": "prettier --write .",
     "lint": "eslint .",
-    "test:serial": "mocha --require ts-node/register --require tsconfig-paths/register --recursive 'src/tests/**/*.ts' --reporter mochawesome --exit"
+    "test:serial": "mocha --require ts-node/register --require tsconfig-paths/register --require src/preflight.ts --recursive 'src/tests/**/*.ts' --reporter mochawesome --exit"
   },
   "devDependencies": {
     "@types/chai": "^5.2.2",

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,0 +1,168 @@
+/**
+ * Run-once preflight for the TCK suite, loaded via mocha `--require` as a
+ * global fixture (runs in the main process before any workers spawn).
+ *
+ * 1. Verifies the three endpoints the suite depends on are reachable — the
+ *    Mirror Node REST API, the consensus node gRPC port, and the SDK JSON-RPC
+ *    server — and aborts the run with a one-line error per unreachable
+ *    endpoint. Motivated by the BNCE 0.75 E2E runs (2026-07-14), where the
+ *    mirror hostname resolved to a loopback alias on the runner box and it
+ *    took a 40-minute run with 613 opaque failures to discover that.
+ * 2. Stamps component versions (TCK, SDK server) and the endpoints in use
+ *    into the console output and mochawesome-report/run-info.json, so every
+ *    run records what was under test. The same BNCE runs were unknowingly
+ *    served by a stale leftover SDK server of unknown version.
+ */
+import "dotenv/config";
+import { lookup } from "node:dns/promises";
+import { Socket } from "node:net";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import axios from "axios";
+
+const TIMEOUT_MS = 5000;
+
+// What the endpoint's hostname actually resolves to on this machine — the
+// BNCE failure mode was /etc/hosts mapping the FQDN to 127.0.2.1.
+const resolvedAddress = async (host: string): Promise<string> => {
+  try {
+    return (await lookup(host)).address;
+  } catch {
+    return "unresolvable (DNS lookup failed)";
+  }
+};
+
+// Any HTTP response (even 4xx/5xx) proves reachability; only transport-level
+// failures (refused, timeout, DNS) count as unreachable.
+const checkHttp = async (name: string, url: string): Promise<string | null> => {
+  const { hostname } = new URL(url);
+  try {
+    await axios.get(url, { timeout: TIMEOUT_MS, validateStatus: () => true });
+    return null;
+  } catch (error: any) {
+    return `${name} unreachable: ${url} (${hostname} resolved to ${await resolvedAddress(
+      hostname,
+    )}) — ${error.code ?? error.message}`;
+  }
+};
+
+const checkTcp = async (
+  name: string,
+  hostPort: string,
+): Promise<string | null> => {
+  const splitAt = hostPort.lastIndexOf(":");
+  const host = hostPort.slice(0, splitAt);
+  const port = Number(hostPort.slice(splitAt + 1));
+
+  const failure = await new Promise<string | null>((resolve) => {
+    const socket = new Socket();
+    socket.setTimeout(TIMEOUT_MS);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(null);
+    });
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolve("connect timed out");
+    });
+    socket.once("error", (error: any) => resolve(error.code ?? error.message));
+    socket.connect(port, host);
+  });
+
+  return failure === null
+    ? null
+    : `${name} unreachable: ${hostPort} (${host} resolved to ${await resolvedAddress(
+        host,
+      )}) — ${failure}`;
+};
+
+// One request doubles as the reachability check and the version query. The
+// current SDK servers don't implement a "version" method, in which case the
+// run is stamped with an explicit "did not report a version".
+const checkJsonRpcServer = async (
+  url: string,
+): Promise<{ failure: string | null; version: string }> => {
+  const { hostname } = new URL(url);
+  try {
+    const response = await axios.post(
+      url,
+      { jsonrpc: "2.0", id: "preflight-version", method: "version" },
+      { timeout: TIMEOUT_MS, validateStatus: () => true },
+    );
+    const result = response.data?.result;
+    const version =
+      result !== undefined
+        ? typeof result === "string"
+          ? result
+          : JSON.stringify(result)
+        : 'did not report a version ("version" method not implemented) — cannot confirm which SDK is under test';
+    return { failure: null, version };
+  } catch (error: any) {
+    return {
+      failure: `SDK JSON-RPC server unreachable: ${url} (${hostname} resolved to ${await resolvedAddress(
+        hostname,
+      )}) — ${error.code ?? error.message}`,
+      version: "unknown (server unreachable)",
+    };
+  }
+};
+
+export async function mochaGlobalSetup(): Promise<void> {
+  const mirrorRestUrl = process.env.MIRROR_NODE_REST_URL;
+  const nodeGrpc = process.env.NODE_IP;
+  const jsonRpcUrl = process.env.JSON_RPC_SERVER_URL ?? "http://localhost:8544";
+
+  const [mirrorFailure, nodeFailure, jsonRpc] = await Promise.all([
+    mirrorRestUrl
+      ? checkHttp("Mirror Node REST", mirrorRestUrl)
+      : Promise.resolve(null),
+    nodeGrpc
+      ? checkTcp("Consensus node gRPC", nodeGrpc)
+      : Promise.resolve(null),
+    checkJsonRpcServer(jsonRpcUrl),
+  ]);
+
+  const tckVersion = JSON.parse(
+    readFileSync(join(__dirname, "..", "package.json"), "utf8"),
+  ).version;
+
+  const runInfo = {
+    startedAt: new Date().toISOString(),
+    tckVersion,
+    sdkServerVersion: jsonRpc.version,
+    endpoints: {
+      jsonRpcServer: jsonRpcUrl,
+      consensusNodeGrpc: nodeGrpc ?? "not set (network default)",
+      mirrorNodeRest: mirrorRestUrl ?? "not set (network default)",
+    },
+  };
+
+  console.log("TCK run info:");
+  console.log(`  TCK version         : ${tckVersion}`);
+  console.log(`  SDK server          : ${jsonRpcUrl}`);
+  console.log(`  SDK server version  : ${jsonRpc.version}`);
+  console.log(`  Consensus node gRPC : ${runInfo.endpoints.consensusNodeGrpc}`);
+  console.log(`  Mirror Node REST    : ${runInfo.endpoints.mirrorNodeRest}`);
+
+  // Best-effort stamp next to the mochawesome report so run artifacts carry
+  // the versions; the reporter only adds files to this directory.
+  try {
+    mkdirSync("mochawesome-report", { recursive: true });
+    writeFileSync(
+      join("mochawesome-report", "run-info.json"),
+      JSON.stringify(runInfo, null, 2),
+    );
+  } catch (error: any) {
+    console.warn(`preflight: could not write run-info.json — ${error.message}`);
+  }
+
+  const failures = [mirrorFailure, nodeFailure, jsonRpc.failure].filter(
+    (failure): failure is string => failure !== null,
+  );
+  if (failures.length > 0) {
+    failures.forEach((failure) => console.error(`preflight: ${failure}`));
+    throw new Error(
+      `preflight: ${failures.length} required endpoint(s) unreachable — aborting before any tests run`,
+    );
+  }
+}


### PR DESCRIPTION
## Motivation

During the BNCE 0.75 E2E validation runs on 2026-07-14 (block-node-infrastructure workflow 150, runs [29303388123](https://github.com/hashgraph/block-node-infrastructure/actions/runs/29303388123) / [29305928452](https://github.com/hashgraph/block-node-infrastructure/actions/runs/29305928452)), two environmental problems cost a lot of triage time:

1. **The Mirror Node was unreachable from the runner box** — the mirror hostname resolved to a loopback alias (`127.0.2.1`) via `/etc/hosts` on the aux server, so every mirror-verifying positive test failed with `ECONNREFUSED`. This only surfaced after a 40-minute run as **613 opaque test failures** that initially looked like consensus-node regressions in a release-gating validation.
2. **Nobody could tell which SDK version was under test** — the freshly started JSON-RPC SDK server crashed with `EADDRINUSE` and both runs were silently served by a stale leftover server instance of unknown version.

This PR makes both failure modes visible up front. It is kept separate from the exit-code reporting fix so that one can merge independently.

## Changes

**1. Preflight connectivity check** (`src/preflight.ts`, a mocha global fixture loaded via `--require` in `test`, `test:file`, and `test:serial`; runs once in the main process before any workers spawn):

- One quick request per endpoint (5s timeout, no retries): HTTP GET to `MIRROR_NODE_REST_URL`, TCP connect to `NODE_IP` (consensus gRPC), JSON-RPC POST to `JSON_RPC_SERVER_URL`.
- On failure the run aborts immediately with a one-line error per endpoint that names the endpoint **and the address its hostname resolved to**, e.g.:
  ```
  preflight: Mirror Node REST unreachable: http://s01.aux...:8000 (s01.aux... resolved to 127.0.2.1) — ECONNREFUSED
  ```
- Endpoints not configured (e.g. testnet mode without `NODE_IP`) are skipped.

**2. Component version stamp** — at suite start the fixture logs and writes to `mochawesome-report/run-info.json` (so run artifacts carry it):

- TCK version (from `package.json`),
- the SDK server version, queried via a JSON-RPC `version` method; since current SDK servers don't implement one, the run is stamped with an explicit `did not report a version ("version" method not implemented) — cannot confirm which SDK is under test` (follow-up idea: add a `version` method to the SDK TCK servers),
- the endpoints in use (mirror REST URL, consensus gRPC address, JSON-RPC server URL).

Example output:
```
TCK run info:
  TCK version         : 0.12.0
  SDK server          : http://127.0.0.1:8544
  SDK server version  : hiero-sdk-js 2.84.0-beta.1
  Consensus node gRPC : s01.csn.bnce.dal.lat.ope.eng.hashgraph.io:50211
  Mirror Node REST    : http://s01.aux.bnce.dal.lat.ope.eng.hashgraph.io:8000
```

## Testing

- Failure path: all three endpoints unreachable → three one-line `preflight:` errors, run aborts before any test executes, non-zero exit.
- Success path: verified against the live BNCE mirror REST + consensus gRPC endpoints and a local stub JSON-RPC server, in both serial and `--parallel` modes (fixture runs exactly once), with both a version-reporting server and one returning `-32601` for `version`.
- `run-info.json` coexists with the mochawesome report files; `prettier` clean, no new eslint errors, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
