### PR TITLE
fix: record optional platform deps in package-lock.json so npm ci works on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "hiero-sdk-tck",
-  "version": "0.8.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.8.0",
+      "version": "0.12.0",
       "dependencies": {
         "@hashgraph/sdk": "^2.73.1",
         "axios": "^1.11.0",
@@ -4724,6 +4724,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/fsu": {
       "version": "1.1.1",


### PR DESCRIPTION
## Problem

`npm ci` fails on macOS:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
npm error Missing: fsevents@2.3.3 from lock file
```

The committed `package-lock.json` was generated on Linux, where `fsevents` (a macOS-only optional dependency pulled in via `jest-haste-map`) is skipped and never recorded, so macOS installs find no lock entry for it.

## Fix

Regenerate the lock file so the `fsevents` entry is recorded. The entry is marked `"optional": true` with `"os": ["darwin"]`, so Linux installs skip it exactly as before — only macOS behavior changes (from hard failure to working install). The regeneration also synced the lock file's stale root `version` field (`0.8.0` → `0.12.0`) with `package.json`; no dependency versions changed.

## Verification

- `npm ci` on macOS (Darwin 25.5.0, npm 11.13.0 / Node 24): previously failed with the error above, now installs cleanly (804 packages) and leaves the lock file unmodified.
- Linux: unchanged behavior (`fsevents` is skipped as an optional darwin-only package); repo CI runs on Linux and will confirm.

Fixes #664
