### PR TITLE
fix: guarantee node-service cleanup, add pre-run sweep and post-run leak verification (#667)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,58 @@ Run all tests
 npm run test
 ```
 
+### Node-service tests and network pollution
+
+The node-service suites submit real `NodeCreate` transactions, which add
+entries to the network's address book. The suites delete every node they
+create when they finish (even after failed assertions), but a run that is
+killed mid-suite leaves phantom nodes behind — on persistent shared
+environments these have hit the `nodes.maxNumber` cap and broken
+consensus-node upgrades.
+
+Three controls exist (see issue #667):
+
+- **Exclude the node-service suites entirely** — the safe default for shared
+  environments:
+
+  ```
+  npm run test:no-node-service
+  ```
+
+- **Sweep leftovers from previous crashed runs** before the suite starts.
+  Off by default; requires both variables, and refuses to run otherwise:
+
+  ```
+  TCK_NODE_SWEEP=true TCK_PROTECTED_NODE_IDS=0,1,2,3 npm run test
+  ```
+
+  `TCK_PROTECTED_NODE_IDS` lists the node IDs of the environment's *real*
+  consensus nodes; every other node is deleted. The sweep walks the node id
+  space on the consensus network itself (node IDs are sequential), because
+  the mirror's `/network/nodes` roster reflects the address book *file*,
+  which regenerates only on upgrades — freshly leaked phantom nodes are
+  invisible there. The sweep (and node cleanup in general, once a leftover
+  node's admin key is lost) requires a **privileged operator** such as the
+  treasury account, since only privileged accounts can delete nodes without
+  their admin keys. Never enable the sweep on a network where non-TCK actors
+  legitimately create nodes.
+
+  > **Note:** deleting nodes does *not* free `nodes.maxNumber` capacity — the
+  > consensus cap counts tombstoned (deleted) nodes until they are purged, so
+  > each full node-service run permanently burns ~46 of the (default 100)
+  > node-id budget between purges. Cleanup prevents roster/upgrade pollution;
+  > it cannot prevent cap exhaustion on a network that never purges. Plan
+  > shared-environment capacity accordingly.
+
+- **Post-run verification** runs automatically whenever a Mirror Node REST
+  URL is configured: the run's successful `NODECREATE` transactions are
+  counted against its successful `NODEDELETE` transactions via the mirror's
+  transaction stream (prompt, unlike the address-book roster). Results are
+  reported in the console and in `mochawesome-report/run-info.json` under
+  `nodes` (`baselineCount`, `createdCount`, `deletedCount`,
+  `mirrorCreatedCount`, `mirrorDeletedCount`, `leakedCount`,
+  `leakedNodeIds`), so CI can gate on `leakedCount == 0`.
+
 ### Reports
 
 After running `npm run test` the generated HTML and JSON reports can be found in the `mochawesome-report` folder

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "rm -rf mochawesome-report && mocha --parallel --jobs 7 --node-option require=ts-node/register --node-option require=tsconfig-paths/register --require src/preflight.ts --recursive 'src/tests/**/*.ts' --timeout 90000 --slow 30000 --reporter mochawesome --exit; node scripts/check-test-results.mjs",
     "test:ci": "rm -rf mochawesome-report && mkdir -p heap-profiles && mocha --parallel --jobs 7 --node-option max-old-space-size=4096 --node-option heap-prof --node-option heap-prof-dir=heap-profiles --node-option require=ts-node/register --node-option require=tsconfig-paths/register --require src/preflight.ts --recursive 'src/tests/**/*.ts' --timeout 90000 --slow 30000 --reporter mochawesome --exit; node scripts/check-test-results.mjs",
     "test:file": "mocha --require ts-node/register --require tsconfig-paths/register --require src/preflight.ts --timeout 90000 --slow 30000 --reporter mochawesome --exit",
+    "test:no-node-service": "rm -rf mochawesome-report && mocha --parallel --jobs 7 --node-option require=ts-node/register --node-option require=tsconfig-paths/register --require src/preflight.ts --recursive 'src/tests/**/*.ts' --ignore 'src/tests/node-service/**' --timeout 90000 --slow 30000 --reporter mochawesome --exit; node scripts/check-test-results.mjs",
     "generate-mirror-node-models": "npx openapi-typescript-codegen --input mirror-node.yaml --output src/utils/models/mirror-node-models",
     "format": "prettier --write .",
     "lint": "eslint .",

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -15,15 +15,33 @@
  * 3. Exports a root hook plugin (`mochaHooks`, runs inside each worker) that
  *    closes the singleton Hashgraph SDK client after each test file, so gRPC
  *    channels don't accumulate for the lifetime of the worker (#645).
+ * 4. Node-pollution controls (issue #667): optionally sweeps leftover nodes
+ *    from prior crashed runs (TCK_NODE_SWEEP=true + TCK_PROTECTED_NODE_IDS)
+ *    by walking the node id space on consensus, and after the run compares
+ *    successful NODECREATE vs NODEDELETE transactions on the mirror — leaks
+ *    are reported loudly and stamped into run-info.json. Motivated by BNCE
+ *    hitting the nodes.maxNumber cap (2026-05-21) and a consensus-node
+ *    upgrade broken by phantom TCK nodes (2026-07-15). Note: the mirror's
+ *    /network/nodes roster reflects the address book file, which regenerates
+ *    only on upgrades — fresh phantom nodes are invisible there, which is why
+ *    neither the sweep nor the leak check can be built on it.
  */
 import "dotenv/config";
 import { lookup } from "node:dns/promises";
 import { Socket } from "node:net";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import axios from "axios";
+import { Long, NodeDeleteTransaction } from "@hashgraph/sdk";
 
 import consensusInfoClient from "./services/ConsensusInfoClient";
+import mirrorNodeClient from "./services/MirrorNodeClient";
 
 // Root hook plugin: in parallel mode `afterAll` runs after each test file in
 // the worker that ran it; in serial mode it runs once at the end of the run.
@@ -121,6 +139,86 @@ const checkJsonRpcServer = async (
   }
 };
 
+const RUN_INFO_PATH = join("mochawesome-report", "run-info.json");
+const NODE_CLEANUP_PATH = join("mochawesome-report", "node-cleanup.jsonl");
+
+const mirrorConfigured = (): boolean =>
+  Boolean(
+    process.env.MIRROR_NODE_REST_JAVA_URL ?? process.env.MIRROR_NODE_REST_URL,
+  );
+
+// Shared between the global setup and teardown (both run in mocha's main
+// process): the address-book roster size at start (informational — the file
+// only regenerates on upgrades, so it can't see fresh nodes) and the moment
+// testing began, which scopes the post-run transaction-window leak check.
+let baselineNodeCount: number | null = null;
+let runStartSeconds: number | null = null;
+
+/**
+ * Deletes every node not in TCK_PROTECTED_NODE_IDS — leftovers from prior
+ * crashed runs, whose admin keys died with the process that generated them.
+ *
+ * Works by walking the node id space on the consensus network itself: ids are
+ * assigned sequentially with no gaps, so attempt NodeDelete from 0 upward —
+ * NODE_DELETED means the id is already gone, and the first INVALID_NODE_ID is
+ * past the end of the id space. The mirror can't drive this: /network/nodes
+ * only reflects the address book file, which regenerates on upgrades, so the
+ * fresh phantoms this sweep exists for are invisible there.
+ *
+ * Requires a privileged operator (e.g. treasury), which is also the only
+ * account that can delete nodes without their admin keys. Destructive, so it
+ * refuses to run without an explicit protected set.
+ */
+const sweepLeftoverNodes = async (): Promise<void> => {
+  const protectedIds = new Set(
+    (process.env.TCK_PROTECTED_NODE_IDS ?? "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+  if (protectedIds.size === 0) {
+    throw new Error(
+      "preflight: TCK_NODE_SWEEP=true requires TCK_PROTECTED_NODE_IDS (comma-separated " +
+        'node IDs of the environment\'s real consensus nodes, e.g. "0,1,2,3"). ' +
+        "Refusing to sweep without a protected set — every unprotected node gets deleted.",
+    );
+  }
+
+  console.log(
+    `preflight: node sweep — walking the node id space (protected: ${[...protectedIds].join(", ")})`,
+  );
+  let swept = 0;
+  // ponytail: serial walk over all ids ever assigned; parallelize in batches
+  // if an environment's id space grows past a few hundred.
+  for (let id = 0; ; id++) {
+    if (protectedIds.has(String(id))) {
+      continue;
+    }
+    try {
+      const response = await new NodeDeleteTransaction()
+        .setNodeId(Long.fromNumber(id))
+        .execute(consensusInfoClient.sdkClient);
+      await response.getReceipt(consensusInfoClient.sdkClient);
+      swept++;
+      console.log(`preflight: node sweep — deleted leftover node ${id}`);
+    } catch (error: any) {
+      const status = error?.status?.toString?.() ?? "";
+      if (status === "INVALID_NODE_ID") {
+        break; // past the end of the assigned id space
+      }
+      if (status !== "NODE_DELETED") {
+        console.error(
+          `preflight: node sweep — unexpected error deleting node ${id} ` +
+            `(is the operator privileged?) — ${error.message}; stopping sweep`,
+        );
+        break;
+      }
+    }
+  }
+  console.log(`preflight: node sweep — deleted ${swept} leftover node(s)`);
+  await consensusInfoClient.close();
+};
+
 export async function mochaGlobalSetup(): Promise<void> {
   const mirrorRestUrl = process.env.MIRROR_NODE_REST_URL;
   const nodeGrpc = process.env.NODE_IP;
@@ -162,10 +260,10 @@ export async function mochaGlobalSetup(): Promise<void> {
   // the versions; the reporter only adds files to this directory.
   try {
     mkdirSync("mochawesome-report", { recursive: true });
-    writeFileSync(
-      join("mochawesome-report", "run-info.json"),
-      JSON.stringify(runInfo, null, 2),
-    );
+    // test:file / test:serial don't wipe the report dir like npm test does —
+    // stale counters from a previous run must not leak into this run's totals.
+    rmSync(NODE_CLEANUP_PATH, { force: true });
+    writeFileSync(RUN_INFO_PATH, JSON.stringify(runInfo, null, 2));
   } catch (error: any) {
     console.warn(`preflight: could not write run-info.json — ${error.message}`);
   }
@@ -177,6 +275,134 @@ export async function mochaGlobalSetup(): Promise<void> {
     failures.forEach((failure) => console.error(`preflight: ${failure}`));
     throw new Error(
       `preflight: ${failures.length} required endpoint(s) unreachable — aborting before any tests run`,
+    );
+  }
+
+  // Node-pollution controls (issue #667) — after the endpoint checks, so the
+  // network is only touched when it's reachable.
+  if (process.env.TCK_NODE_SWEEP === "true") {
+    await sweepLeftoverNodes();
+  }
+
+  if (mirrorConfigured()) {
+    try {
+      baselineNodeCount = (await mirrorNodeClient.getAllNetworkNodeIds())
+        .length;
+      console.log(
+        `  Address book baseline: ${baselineNodeCount} node(s) (fresh DAB nodes not included)`,
+      );
+    } catch (error: any) {
+      console.warn(
+        `preflight: could not snapshot the node roster — ${error.message}`,
+      );
+    }
+  }
+
+  // Scopes the teardown's leak check to this run's transactions. Set after
+  // the sweep so the sweep's own NodeDelete transactions stay out of the
+  // window.
+  runStartSeconds = Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Post-run pollution check: counts this run's successful NODECREATE vs
+ * NODEDELETE transactions on the mirror (the address book roster can't see
+ * fresh DAB nodes, so the transaction stream is the only prompt view). Leaks
+ * are reported loudly and stamped into run-info.json (`nodes.leakedCount`) so
+ * CI consumers can gate on it, but the run is not failed here — a crashed
+ * cleanup already surfaced its own error.
+ */
+export async function mochaGlobalTeardown(): Promise<void> {
+  // Aggregate the per-worker cleanup counters written by the node registry.
+  const counts = {
+    created: 0,
+    deleted: 0,
+    cleanupFailed: 0,
+    cleanupFailedIds: [] as string[],
+  };
+  if (existsSync(NODE_CLEANUP_PATH)) {
+    for (const line of readFileSync(NODE_CLEANUP_PATH, "utf8")
+      .split("\n")
+      .filter(Boolean)) {
+      const workerCounts = JSON.parse(line);
+      counts.created += workerCounts.created;
+      counts.deleted +=
+        workerCounts.deletedByTests + workerCounts.cleanupDeleted;
+      counts.cleanupFailed += workerCounts.cleanupFailed;
+      counts.cleanupFailedIds.push(...(workerCounts.cleanupFailedIds ?? []));
+    }
+  }
+
+  let mirrorCreated: number | null = null;
+  let mirrorDeleted: number | null = null;
+  let leaked: number | null = null;
+  if (mirrorConfigured() && runStartSeconds !== null) {
+    try {
+      // ponytail: 5×3s poll to ride out mirror ingest lag on the run's final
+      // deletes; bump if an environment ingests slower than ~15 s.
+      for (let attempt = 0; attempt < 5; attempt++) {
+        mirrorCreated = await mirrorNodeClient.countSuccessfulTransactions(
+          "NODECREATE",
+          runStartSeconds,
+        );
+        mirrorDeleted = await mirrorNodeClient.countSuccessfulTransactions(
+          "NODEDELETE",
+          runStartSeconds,
+        );
+        leaked = mirrorCreated - mirrorDeleted;
+        if (leaked <= 0) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+      }
+    } catch (error: any) {
+      console.warn(
+        `node-pollution check: could not query the mirror transaction stream — ${error.message}`,
+      );
+    }
+  }
+
+  const summary = {
+    baselineCount: baselineNodeCount,
+    createdCount: counts.created,
+    deletedCount: counts.deleted,
+    cleanupFailedCount: counts.cleanupFailed,
+    mirrorCreatedCount: mirrorCreated,
+    mirrorDeletedCount: mirrorDeleted,
+    leakedCount: leaked,
+    leakedNodeIds: counts.cleanupFailedIds,
+  };
+
+  console.log(
+    `node-pollution check: created ${summary.createdCount}, deleted ${summary.deletedCount} (registry); ` +
+      `created ${mirrorCreated ?? "?"}, deleted ${mirrorDeleted ?? "?"} (mirror); ` +
+      `leaked ${leaked ?? "unknown (no mirror)"}`,
+  );
+  if (leaked !== null && leaked > 0) {
+    const knownIds =
+      counts.cleanupFailedIds.length > 0
+        ? `known leaked ids: ${counts.cleanupFailedIds.join(", ")}`
+        : "ids unknown (cleanup died before recording them)";
+    console.error(
+      `\n${"!".repeat(72)}\n` +
+        `node-pollution check: ${leaked} phantom node(s) LEAKED by this run — ${knownIds}\n` +
+        `Delete them manually or run with TCK_NODE_SWEEP=true (see README) — ` +
+        `leftover nodes have capped BNCE at nodes.maxNumber and broken CN upgrades.\n` +
+        `${"!".repeat(72)}\n`,
+    );
+  }
+
+  try {
+    const runInfo = existsSync(RUN_INFO_PATH)
+      ? JSON.parse(readFileSync(RUN_INFO_PATH, "utf8"))
+      : {};
+    writeFileSync(
+      RUN_INFO_PATH,
+      JSON.stringify({ ...runInfo, nodes: summary }, null, 2),
+    );
+  } catch (error: any) {
+    console.warn(
+      `node-pollution check: could not update run-info.json — ${error.message}`,
     );
   }
 }

--- a/src/services/Client.ts
+++ b/src/services/Client.ts
@@ -2,6 +2,8 @@ import { JSONRPC, JSONRPCClient, CreateID } from "json-rpc-2.0";
 import axios from "axios";
 import "dotenv/config";
 
+import { trackNode, untrackNode } from "@helpers/node-registry";
+
 let nextID = 0;
 const createID: CreateID = () => nextID++;
 
@@ -129,6 +131,20 @@ export const JSONRPCRequest = async (
       jsonRPCResponse.result.error === "NOT_IMPLEMENTED"
     ) {
       mochaTestContext.skip();
+    }
+    // Nodes created on the network under test are real address-book entries
+    // and must be deleted again (issue #667). Tracking lives here so every
+    // suite gets it without per-test bookkeeping.
+    if (
+      method === "createNode" &&
+      jsonRPCResponse.result.nodeId !== undefined
+    ) {
+      trackNode(
+        String(jsonRPCResponse.result.nodeId),
+        params?.commonTransactionParams?.signers ?? [],
+      );
+    } else if (method === "deleteNode" && params?.nodeId !== undefined) {
+      untrackNode(String(params.nodeId));
     }
     return jsonRPCResponse.result;
   }

--- a/src/services/MirrorNodeClient.ts
+++ b/src/services/MirrorNodeClient.ts
@@ -118,6 +118,63 @@ class MirrorNodeClient {
       fetchData(url).catch(() => fetchData(legacyUrl)),
     );
   }
+
+  /**
+   * Counts successful transactions of the given type (e.g. "NODECREATE")
+   * with a consensus timestamp at or after `sinceSeconds`, following
+   * pagination. Used by the post-run node-pollution check (issue #667):
+   * /network/nodes only reflects the address book file, which regenerates on
+   * upgrades, so freshly created nodes are invisible there — the transaction
+   * stream is the only prompt REST view of node churn.
+   */
+  async countSuccessfulTransactions(
+    transactionType: string,
+    sinceSeconds: number,
+  ): Promise<number> {
+    const baseUrl = this.mirrorNodeRestUrl!;
+    // Promise<any> because retryOnError's fn parameter is typed () => Promise<void>.
+    return retryOnError(async (): Promise<any> => {
+      // count/path live inside the closure so a retry restarts from scratch
+      let count = 0;
+      let path: string | null =
+        `/api/v1/transactions?transactiontype=${transactionType}&result=success&timestamp=gte:${sinceSeconds}&limit=100`;
+      while (path) {
+        const page: any = await fetchData(new URL(path, baseUrl).toString());
+        count += page.transactions.length;
+        path = page.links?.next ?? null;
+      }
+      return count;
+    });
+  }
+
+  /**
+   * Returns the node IDs of every node in the network's address book,
+   * following pagination. Used for the informational baseline stamp in
+   * run-info.json (issue #667). NOTE: reflects the address book file only —
+   * nodes created since the last upgrade/freeze do not appear here.
+   */
+  async getAllNetworkNodeIds(): Promise<string[]> {
+    const baseUrl = this.mirrorNodeRestJavaUrl ?? this.mirrorNodeRestUrl;
+    const legacyBaseUrl = this.mirrorNodeRestUrl;
+
+    // Promise<any> because retryOnError's fn parameter is typed () => Promise<void>.
+    const listFrom = async (base: string): Promise<any> => {
+      const nodeIds: string[] = [];
+      let path: string | null = "/api/v1/network/nodes?limit=100";
+      while (path) {
+        const page: NetworkNodesResponse = await fetchData(
+          new URL(path, base).toString(),
+        );
+        nodeIds.push(...page.nodes.map((node) => String(node.node_id)));
+        path = page.links?.next ?? null;
+      }
+      return nodeIds;
+    };
+
+    return retryOnError(async () =>
+      listFrom(baseUrl!).catch(() => listFrom(legacyBaseUrl!)),
+    );
+  }
 }
 
 export default new MirrorNodeClient();

--- a/src/tests/node-service/test-node-create-transaction.ts
+++ b/src/tests/node-service/test-node-create-transaction.ts
@@ -4,6 +4,7 @@ import { assert, expect } from "chai";
 import { JSONRPCRequest } from "@services/Client";
 
 import { setOperator } from "@helpers/setup-tests";
+import { deleteTrackedNodes } from "@helpers/node-registry";
 import {
   generateEd25519PrivateKey,
   generateEcdsaSecp256k1PrivateKey,
@@ -38,6 +39,9 @@ describe("NodeCreateTransaction", function () {
   });
 
   after(async function () {
+    // Delete the real address-book entries this suite created (issue #667),
+    // while the session and its operator are still alive.
+    await deleteTrackedNodes(this);
     await JSONRPCRequest(this, "reset", {
       sessionId: this.sessionId,
     });

--- a/src/tests/node-service/test-node-delete-transaction.ts
+++ b/src/tests/node-service/test-node-delete-transaction.ts
@@ -8,6 +8,7 @@ import {
   setOperatorForExistingSession,
 } from "@helpers/setup-tests";
 import { generateEd25519PrivateKey } from "@helpers/key";
+import { deleteTrackedNodes } from "@helpers/node-registry";
 
 import { ErrorStatusCodes } from "@enums/error-status-codes";
 import { toHexString } from "@helpers/verify-contract-tx";
@@ -29,6 +30,9 @@ describe("NodeDeleteTransaction", function () {
   });
 
   after(async function () {
+    // Delete surviving fixture nodes — happy-path deletes untrack themselves,
+    // so this only cleans up after failed delete assertions (issue #667).
+    await deleteTrackedNodes(this);
     await JSONRPCRequest(this, "reset", {
       sessionId: this.sessionId,
     });

--- a/src/tests/node-service/test-node-update-transaction.ts
+++ b/src/tests/node-service/test-node-update-transaction.ts
@@ -3,6 +3,7 @@ import { assert, expect } from "chai";
 import { JSONRPCRequest } from "@services/Client";
 
 import { setOperator } from "@helpers/setup-tests";
+import { deleteTrackedNodes } from "@helpers/node-registry";
 import {
   generateEcdsaSecp256k1PrivateKey,
   generateEcdsaSecp256k1PublicKey,
@@ -91,6 +92,9 @@ describe("NodeUpdateTransaction", function () {
   });
 
   after(async function () {
+    // Delete the real address-book entries this suite created (issue #667),
+    // while the session and its operator are still alive.
+    await deleteTrackedNodes(this);
     await JSONRPCRequest(this, "reset", {
       sessionId: this.sessionId,
     });

--- a/src/utils/helpers/node-registry.ts
+++ b/src/utils/helpers/node-registry.ts
@@ -1,0 +1,106 @@
+/**
+ * Registry of nodes created on the network under test, so suites can delete
+ * them again. NodeCreate transactions submitted by the node-service tests
+ * create REAL address-book entries on persistent environments; leftovers have
+ * hit the `nodes.maxNumber` cap (BNCE, 2026-05-21) and broken a consensus-node
+ * upgrade (BNCE, 2026-07-15). See issue #667.
+ *
+ * Tracking is wired into the JSON-RPC client (services/Client.ts): every
+ * successful `createNode` is tracked here together with the signer keys the
+ * test used to create it, and every successful `deleteNode` untracks — so
+ * tests that already delete their own nodes need no cleanup. Suites that
+ * create nodes call `deleteTrackedNodes(this)` in their `after()` hook,
+ * before the session reset.
+ *
+ * State is per-process: under mocha --parallel each test file runs in its own
+ * worker, so a suite only ever drains the nodes its own file created.
+ */
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { JSONRPCRequest } from "@services/Client";
+
+// nodeId -> signer private keys from the createNode call. Replaying the
+// create's signers on delete always suffices: a successful create carries a
+// valid admin-key signature, so the admin private key is in this list (or the
+// operator is privileged and needs no signature at all).
+const trackedNodes = new Map<string, string[]>();
+
+const counters = {
+  created: 0,
+  deletedByTests: 0,
+  cleanupDeleted: 0,
+  cleanupFailed: 0,
+  cleanupFailedIds: [] as string[],
+};
+
+export const trackNode = (nodeId: string, signers: string[]): void => {
+  trackedNodes.set(nodeId, signers);
+  counters.created++;
+};
+
+export const untrackNode = (nodeId: string): void => {
+  if (trackedNodes.delete(nodeId)) {
+    counters.deletedByTests++;
+  }
+};
+
+/**
+ * Deletes every tracked node that still exists. Called from suite `after()`
+ * hooks, which mocha runs even when tests fail — so cleanup happens for
+ * failed assertions too. Never throws: a failed delete must not mask the
+ * test failure that preceded it, so it is logged and the drain continues.
+ */
+export const deleteTrackedNodes = async (
+  mochaTestContext: any,
+): Promise<void> => {
+  // Snapshot and clear first: the deleteNode calls below re-enter the
+  // client's untrackNode hook, which must not double-count them as
+  // test-initiated deletes.
+  const remaining = [...trackedNodes];
+  trackedNodes.clear();
+
+  for (const [nodeId, signers] of remaining) {
+    try {
+      await JSONRPCRequest(mochaTestContext, "deleteNode", {
+        nodeId,
+        ...(signers.length > 0 && {
+          commonTransactionParams: { signers },
+        }),
+      });
+      counters.cleanupDeleted++;
+    } catch (error: any) {
+      if (error?.data?.status === "NODE_DELETED") {
+        // Already gone (deleted outside the client's untrack path) — fine.
+        counters.cleanupDeleted++;
+      } else {
+        counters.cleanupFailed++;
+        counters.cleanupFailedIds.push(nodeId);
+        console.error(
+          `node-registry: failed to delete node ${nodeId} — ${
+            error?.data?.status ?? error?.message ?? error
+          }`,
+        );
+      }
+    }
+  }
+
+  // Per-worker summary line; the preflight global teardown (main process)
+  // aggregates these into mochawesome-report/run-info.json.
+  try {
+    mkdirSync("mochawesome-report", { recursive: true });
+    appendFileSync(
+      join("mochawesome-report", "node-cleanup.jsonl"),
+      JSON.stringify(counters) + "\n",
+    );
+    counters.created = 0;
+    counters.deletedByTests = 0;
+    counters.cleanupDeleted = 0;
+    counters.cleanupFailed = 0;
+    counters.cleanupFailedIds = [];
+  } catch (error: any) {
+    console.warn(
+      `node-registry: could not write node-cleanup.jsonl — ${error.message}`,
+    );
+  }
+};


### PR DESCRIPTION
Resolves https://github.com/hiero-ledger/hiero-sdk-tck/issues/667

## What this does

The node-service suites submit real `NodeCreate` transactions and nothing ever deleted them, polluting persistent environments (BNCE `nodes.maxNumber` cap incident 2026-05-21; phantom nodes breaking a CN upgrade 2026-07-15). This PR adds three layers of protection plus an operational escape hatch:

### 1. Guaranteed in-suite cleanup (deterministic path)

Tracking is wired into the one choke point every suite already routes through — `JSONRPCRequest` in `src/services/Client.ts`. A successful `createNode` registers the node ID together with the create's signer keys (a successful create always carries a valid admin-key signature, so the admin private key is in that list); a successful `deleteNode` unregisters. No per-test bookkeeping anywhere.

The three node-creating suites drain the registry via `deleteTrackedNodes(this)` at the top of their existing `after()` hooks — before the session reset, while the operator is still alive. Mocha runs `after()` even when tests fail, so cleanup covers failed assertions; the drain never throws, so a failed delete cannot mask the original test failure (it is logged and the drain continues). The delete suite needs no special handling: its happy-path deletes untrack themselves through the client hook, so only fixtures whose delete assertion failed remain for the drain. `test-address-book-query.ts` was audited and creates no nodes.

### 2. Pre-run sweep (heals pollution from crashed runs)

`TCK_NODE_SWEEP=true` + `TCK_PROTECTED_NODE_IDS=<ids>` enables a preflight sweep that deletes every node not in the protected set. It refuses to run if the protected set is empty/unconfigured, and requires a privileged operator (leftover nodes' admin keys died with the process that generated them; only privileged accounts can delete nodes without them).

**Deviation from the issue text, discovered during verification:** the issue suggests driving the sweep from Mirror Node `/api/v1/network/nodes`. That endpoint reflects the address book *file*, which regenerates only on upgrades — freshly leaked phantom nodes are invisible there (verified empirically on mirror `0.154.0`: a live phantom node absent from the endpoint minutes after creation, while present in the mirror's `node` DB table). The sweep instead walks the node-id space on consensus itself: node IDs are assigned sequentially with no gaps, so it attempts `NodeDelete` from 0 upward — `NODE_DELETED` means the id is already gone, and the first `INVALID_NODE_ID` is past the end of the id space. (The suite's own tests #2/#4 assert exactly these status semantics.) This makes the sweep mirror-independent and immune to ingest/upgrade lag.

### 3. Post-run verification

For the same reason, the post-run check does not compare rosters. It counts this run's successful `NODECREATE` vs `NODEDELETE` transactions via the mirror's transaction stream (`/api/v1/transactions?transactiontype=…&result=success&timestamp=gte:<run start>`), which ingests promptly. The result is stamped into `mochawesome-report/run-info.json`:

```json
"nodes": {
  "baselineCount": 1,
  "createdCount": 46,
  "deletedCount": 46,
  "cleanupFailedCount": 0,
  "mirrorCreatedCount": 46,
  "mirrorDeletedCount": 46,
  "leakedCount": 0,
  "leakedNodeIds": []
}
```

`createdCount`/`deletedCount` come from the in-process registry (aggregated across parallel workers via a jsonl file); `mirror*` counts are the independent view; CI can gate on `leakedCount == 0`. Leaks also print a loud console banner. The run is not failed on a leak — a crashed cleanup already surfaced its own error.

### 4. Escape hatch + docs

`npm run test:no-node-service` runs the full suite excluding the node-service specs. The README documents the exclusion, sweep configuration, privileged-operator requirement, and a capacity caveat (below).

## How this was verified

Everything below ran against a real network: fresh `solo one-shot single` deployments (solo CLI 0.77.0, consensus single node, mirror node 0.154.0 with rest + rest-java), driven by the hiero-sdk-js TCK JSON-RPC server (published SDK 2.84.0) with the treasury account `0.0.2` as operator. Ground truth was checked directly in the mirror's Postgres `node` table (`deleted` flags), independent of any code in this PR.

### Full round-trip leaves the network at baseline (serial AND parallel)

All four node-service suites, serial (`test:file`) and then parallel (`--parallel --jobs 7`, the CI configuration) on a fresh network:

```
  146 passing (58s)   # serial
  146 passing (34s)   # parallel
  10 pending
node-pollution check: created 46, deleted 46 (registry); created 46, deleted 46 (mirror); leaked 0
```

Mirror DB after each run: `live: 1` (only the real consensus node). The registry, the mirror transaction window, and the consensus DB agree exactly.

### Kill -9 mid-suite, then sweep recovery

A run was `kill -9`ed mid-create-suite (triggered off test progress in the log, so no `after()` hook could run):

```
killed mocha at 15 passing tests — no cleanup hook could run
 live nodes on network: 11        # node 0 + 10 phantoms, from the mirror DB
```

The next run with `TCK_NODE_SWEEP=true TCK_PROTECTED_NODE_IDS=0`:

```
preflight: node sweep — walking the node id space (protected: 0)
preflight: node sweep — deleted leftover node 77
...                                (78–85 elided)
preflight: node sweep — deleted leftover node 86
preflight: node sweep — deleted 10 leftover node(s)
  6 passing (3s)
node-pollution check: ... leaked 0
 live nodes after sweep run: 1
```

All 10 phantoms deleted before testing, the protected real node untouched, baseline restored.

### Failed assertion still cleans up

With create test #1's assertion deliberately broken after a successful `createNode`:

```
  1 failing
      AssertionError: expected 'SUCCESS' to equal 'DELIBERATELY_BROKEN_FOR_667_CHECK'
node-pollution check: created 1, deleted 1 (registry); ... leaked 0
 live nodes after failed-assertion run: 1
```

The test reported its original failure and its node was still deleted. (The break was reverted before commit.)

### Sweep gating and unit-level behavior

A stub-server self-check (a local HTTP server playing both the mirror REST API with pagination and the SDK JSON-RPC server) exercises the real modules end-to-end: mirror pagination and query construction, the client's track/untrack hooks, drain counters, the jsonl aggregation, sweep refusal without a protected set, and the leak banner + `run-info.json` contents for both clean and leaking runs. It caught two real bugs during development (a drain double-count via hook re-entry, and stale jsonl counters accumulating across `test:file` runs), both fixed in this PR.

## Finding for the BN team: deletion does not free `nodes.maxNumber` capacity

While verifying, the repeated runs organically reproduced the 2026-05-21 incident: at exactly **100 nodes ever created** (1 live, 99 deleted — mirror DB: `total node rows: 100, live: 1`), every `NodeCreate` fails with `MAX_NODES_CREATED`. The consensus cap counts tombstoned (deleted) nodes until they are purged, so **each full node-service run permanently burns ~46 of the default-100 node-id budget even with perfect cleanup** (~2 runs exhaust a never-upgraded network; on a fresh solo deployment the second parallel run failed en masse with `MAX_NODES_CREATED` until redeploy). This PR prevents roster/upgrade pollution — the 2026-07-15 incident — but cap exhaustion needs an environment-side answer (raise `nodes.maxNumber` on BNCE and/or confirm tombstone purge semantics with the services team). Noted in the README.

## Out of scope

Per the issue: no generalization to other entity types; the registry is node-only.