### PR TITLE
fix: accept auto-estimated gas in ContractCallQuery no-gas test

### DIFF
--- a/docs/test-specifications/contract-service/ContractCallQuery.md
+++ b/docs/test-specifications/contract-service/ContractCallQuery.md
@@ -102,7 +102,7 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 | Test no | Name                                                      | Input             | Expected response                                                                       | Implemented (Y/N) |
 |---------|-----------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------|-------------------|
 | 1       | Executes contract call query with valid gas amount       | gas=100000        | The contract call query succeeds and gasUsed < gas                                      | Y                 |
-| 2       | Fails to execute without gas                              |                   | The contract call query fails and returns INSUFFICIENT_GAS                              | Y                 |
+| 2       | Executes contract call query without gas                  |                   | The query succeeds if the SDK auto-estimates gas (e.g. via the mirror node), otherwise it fails and returns INSUFFICIENT_GAS | Y                 |
 | 3       | Fails to execute with insufficient gas                    | gas=100           | The contract call query fails and returns INSUFFICIENT_GAS                              | Y                 |
 | 4       | Executes contract call query with maximum gas             | gas=1000000       | The contract call query succeeds                                                        | Y                 |
 

--- a/src/tests/contract-service/test-contract-call-query.ts
+++ b/src/tests/contract-service/test-contract-call-query.ts
@@ -183,17 +183,22 @@ describe("ContractCallQuery", function () {
       expect(parseInt(response.gasUsed)).to.be.lessThan(100000);
     });
 
-    it("(#2) Fails to execute contract call query without gas", async function () {
+    it("(#2) Executes contract call query without gas", async function () {
+      // An SDK may auto-estimate gas via the mirror node when it is omitted
+      // (e.g. JS SDK >= 2.86.0) and execute the query successfully; SDKs
+      // without gas estimation submit gas=0 and the network rejects the
+      // query with INSUFFICIENT_GAS.
       try {
-        await JSONRPCRequest(this, "contractCallQuery", {
+        const response = await JSONRPCRequest(this, "contractCallQuery", {
           contractId,
           functionName: "getMessage",
         });
+
+        expect(response).to.not.be.null;
+        expect(response.rawResult).to.not.be.null;
       } catch (err: any) {
         assert.equal(err.data.status, "INSUFFICIENT_GAS");
-        return;
       }
-      assert.fail("Should throw an error");
     });
 
     it("(#3) Fails to execute contract call query with insufficient gas", async function () {


### PR DESCRIPTION
## Description

The Gas test "(#2) Fails to execute contract call query without gas" expects `INSUFFICIENT_GAS` when `gas` is omitted. Since `@hiero-ledger/sdk` (JS) v2.86.0, a `ContractCallQuery` without an explicit gas amount auto-estimates gas via the mirror node ([hiero-sdk-js#2848](https://github.com/hiero-ledger/hiero-sdk-js/issues/2848)) and the query succeeds, so this test now fails against the JS SDK — it is one of the failures in the consensus-node nightly SDK TCK Regression panel (e.g. [this run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/30021818169)); the other four are addressed by #670.

Other SDKs (e.g. Java) do not auto-estimate and still submit `gas=0`, which the network rejects with `INSUFFICIENT_GAS`, so the test cannot simply assert success either.

## Changes

- Test #2 now accepts both valid SDK behaviors: a successful response (gas auto-estimated) or an `INSUFFICIENT_GAS` error (no gas estimation). The explicit `INSUFFICIENT_GAS` path remains fully covered by test #3 (`gas=100`).
- Updated `docs/test-specifications/contract-service/ContractCallQuery.md` accordingly.

## Notes

The nightly TCK panel pins `tck-version=v0.12.0` in consensus-node's `.citr-env`; after this merges, a new tag and a version bump there are needed for the panel to pick up both this fix and #670 (v0.12.1).