### PR TITLE
fix: accept SDK-side gas-required error in ContractCallQuery no-gas test

### DIFF
--- a/docs/test-specifications/contract-service/ContractCallQuery.md
+++ b/docs/test-specifications/contract-service/ContractCallQuery.md
@@ -102,7 +102,7 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 | Test no | Name                                                      | Input             | Expected response                                                                       | Implemented (Y/N) |
 |---------|-----------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------|-------------------|
 | 1       | Executes contract call query with valid gas amount       | gas=100000        | The contract call query succeeds and gasUsed < gas                                      | Y                 |
-| 2       | Executes contract call query without gas                  |                   | The query succeeds if the SDK auto-estimates gas (e.g. via the mirror node), otherwise it fails and returns INSUFFICIENT_GAS | Y                 |
+| 2       | Executes contract call query without gas                  |                   | The query succeeds if the SDK auto-estimates gas (e.g. via the mirror node); an auto-estimating SDK fails with an SDK-side "requires gas to be set" error when the estimation endpoint is unavailable; otherwise it fails and returns INSUFFICIENT_GAS | Y                 |
 | 3       | Fails to execute with insufficient gas                    | gas=100           | The contract call query fails and returns INSUFFICIENT_GAS                              | Y                 |
 | 4       | Executes contract call query with maximum gas             | gas=1000000       | The contract call query succeeds                                                        | Y                 |
 

--- a/src/tests/contract-service/test-contract-call-query.ts
+++ b/src/tests/contract-service/test-contract-call-query.ts
@@ -185,9 +185,12 @@ describe("ContractCallQuery", function () {
 
     it("(#2) Executes contract call query without gas", async function () {
       // An SDK may auto-estimate gas via the mirror node when it is omitted
-      // (e.g. JS SDK >= 2.86.0) and execute the query successfully; SDKs
-      // without gas estimation submit gas=0 and the network rejects the
-      // query with INSUFFICIENT_GAS.
+      // (e.g. JS SDK >= 2.86.0) and execute the query successfully; when the
+      // mirror node estimation endpoint (/api/v1/contracts/call, served by
+      // the mirror web3 service) is unavailable, such an SDK fails with an
+      // SDK-side "requires gas to be set" error instead. SDKs without gas
+      // estimation submit gas=0 and the network rejects the query with
+      // INSUFFICIENT_GAS.
       try {
         const response = await JSONRPCRequest(this, "contractCallQuery", {
           contractId,
@@ -197,7 +200,14 @@ describe("ContractCallQuery", function () {
         expect(response).to.not.be.null;
         expect(response.rawResult).to.not.be.null;
       } catch (err: any) {
-        assert.equal(err.data.status, "INSUFFICIENT_GAS");
+        if (err.data?.status) {
+          assert.equal(err.data.status, "INSUFFICIENT_GAS");
+        } else {
+          assert.include(
+            err.data?.message ?? err.message ?? "",
+            "requires gas to be set",
+          );
+        }
       }
     });
 


### PR DESCRIPTION
## Description

Follow-up to #672. The CITR XTS dry run against TCK v0.12.2 ([run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/30098615934/job/89500122099)) is down from 5 failures to 1, but the reworked Gas test #2 still fails there:

```
AssertionError: expected undefined to equal 'INSUFFICIENT_GAS'
```

The solo network in that panel only exposes the mirror `rest`, `restjava`, and `grpc` services — not the mirror **web3** service that serves `/api/v1/contracts/call`, which the JS SDK's gas auto-estimation uses. With estimation unreachable, the JS SDK (>= 2.86.0) throws its SDK-side error ("ContractCallQuery requires gas to be set. Automatic gas estimation via the mirror node failed: ..."), which the TCK server surfaces as a JSON-RPC internal error with `data.message` but no `data.status` — so the previous catch branch read `undefined`.

(#672's own JS compatibility CI passed because its environment has a full mirror node, so estimation succeeded and took the success branch.)

## Changes

Test #2 now distinguishes the error shape:
- Hedera status error (`err.data.status` present) → must be `INSUFFICIENT_GAS` (SDKs that submit `gas=0`)
- otherwise → must be the SDK-side "requires gas to be set" error (auto-estimating SDK, estimation endpoint unavailable)

The success path (estimation available) is unchanged, and the explicit `INSUFFICIENT_GAS` coverage remains in test #3. Spec doc updated accordingly.