### PR TITLE
chore: update solo version to 0.69.1

### DIFF
--- a/.github/workflows/cpp_compatibility.yml
+++ b/.github/workflows/cpp_compatibility.yml
@@ -12,10 +12,10 @@ on:
         required: false
         type: string
       solo-version:
-        description: "The version of the Solo to use (defaults to 0.69.0 if not specified):"
+        description: "The version of the Solo to use (defaults to 0.69.1 if not specified):"
         required: false
         type: string
-        default: "0.69.0"
+        default: "0.69.1"
       consensus-node-version:
         description: "The version of the consensus node to use (defaults to latest stable version tag if not specified):"
         required: false
@@ -34,7 +34,7 @@ on:
         description: "The version of the Solo to use"
         required: false
         type: string
-        default: "0.69.0"
+        default: "0.69.1"
       consensus-node-version:
         description: "The version of the consensus node to use"
         required: false
@@ -193,7 +193,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
           installMirrorNode: true
-          soloVersion: ${{ inputs.solo-version || '0.69.0' }}
+          soloVersion: ${{ inputs.solo-version || '0.69.1' }}
           mirrorNodeVersion: v0.138.0
           hieroVersion: ${{ inputs.consensus-node-version || steps.get-consensus-version.outputs.tag }}
 

--- a/.github/workflows/go_compatibility.yml
+++ b/.github/workflows/go_compatibility.yml
@@ -12,10 +12,10 @@ on:
         required: false
         type: string
       solo-version:
-        description: "The version of the Solo to use (defaults to 0.69.0 if not specified):"
+        description: "The version of the Solo to use (defaults to 0.69.1 if not specified):"
         required: false
         type: string
-        default: "0.69.0"
+        default: "0.69.1"
       consensus-node-version:
         description: "The version of the consensus node to use (defaults to latest stable version tag if not specified):"
         required: false
@@ -34,7 +34,7 @@ on:
         description: "The version of the Solo to use"
         required: false
         type: string
-        default: "0.69.0"
+        default: "0.69.1"
       consensus-node-version:
         description: "The version of the consensus node to use"
         required: false
@@ -147,7 +147,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
           installMirrorNode: true
-          soloVersion: ${{ inputs.solo-version || '0.69.0' }}
+          soloVersion: ${{ inputs.solo-version || '0.69.1' }}
           mirrorNodeVersion: v0.138.0
           hieroVersion: ${{ inputs.consensus-node-version || steps.get-consensus-version.outputs.tag }}
 

--- a/.github/workflows/java_compatibility.yml
+++ b/.github/workflows/java_compatibility.yml
@@ -12,10 +12,10 @@ on:
         required: false
         type: string
       solo-version:
-        description: "The version of the Solo to use (defaults to 0.69.0 if not specified):"
+        description: "The version of the Solo to use (defaults to 0.69.1 if not specified):"
         required: false
         type: string
-        default: "0.69.0"
+        default: "0.69.1"
       consensus-node-version:
         description: "The version of the consensus node to use (defaults to latest stable version tag if not specified):"
         required: false
@@ -34,7 +34,7 @@ on:
         description: "The version of the Solo to use"
         required: false
         type: string
-        default: "0.69.0"
+        default: "0.69.1"
       consensus-node-version:
         description: "The version of the consensus node to use"
         required: false
@@ -173,7 +173,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
           installMirrorNode: true
-          soloVersion: ${{ inputs.solo-version || '0.69.0' }}
+          soloVersion: ${{ inputs.solo-version || '0.69.1' }}
           mirrorNodeVersion: v0.138.0
           hieroVersion: ${{ inputs.consensus-node-version || steps.get-consensus-version.outputs.tag }}
 

--- a/.github/workflows/js_compatibility.yml
+++ b/.github/workflows/js_compatibility.yml
@@ -12,10 +12,10 @@ on:
         required: false
         type: string
       solo-version:
-        description: "The version of the Solo to use (defaults to 0.69.0 if not specified):"
+        description: "The version of the Solo to use (defaults to 0.69.1 if not specified):"
         required: false
         type: string
-        default: "0.69.0"
+        default: "0.69.1"
       consensus-node-version:
         description: "The version of the consensus node to use (defaults to latest stable version tag if not specified):"
         required: false
@@ -34,7 +34,7 @@ on:
         description: "The version of the Solo to use"
         required: false
         type: string
-        default: "0.69.0"
+        default: "0.69.1"
       consensus-node-version:
         description: "The version of the consensus node to use"
         required: false
@@ -154,7 +154,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@328bc84c3b00a990a151418144fd682a4eb76ea6 # v0.19.0
         with:
           installMirrorNode: true
-          soloVersion: ${{ inputs.solo-version || '0.69.0' }}
+          soloVersion: ${{ inputs.solo-version || '0.69.1' }}
           mirrorNodeVersion: v0.138.0
           hieroVersion: ${{ inputs.consensus-node-version || steps.get-consensus-version.outputs.tag }}
 


### PR DESCRIPTION
## Summary
- Bumps the default Solo CLI version from `0.69.0` to `0.69.1` across `cpp_compatibility.yml`, `go_compatibility.yml`, `java_compatibility.yml`, and `js_compatibility.yml` (input description, `workflow_dispatch`/`workflow_call` defaults, and the `soloVersion` fallback expression).