### PR TITLE
fix(ci): revert consensus node version selection to stable-only tags

### DIFF
--- a/.github/workflows/cpp_compatibility.yml
+++ b/.github/workflows/cpp_compatibility.yml
@@ -176,12 +176,11 @@ jobs:
         if: ${{ !inputs.consensus-node-version }}
         id: get-consensus-version
         run: |
-          # Fetch latest stable or RC version (excludes alpha, beta versions)
-          # TODO: revert to stable-only once v0.76.0 is released (see hiero-ledger/hiero-sdk-tck#671)
+          # Fetch latest stable version (excludes RC, beta, alpha versions)
           LATEST_TAG=$(git ls-remote --tags --refs https://github.com/hiero-ledger/hiero-consensus-node \
             | awk '{print $2}' \
             | sed 's|refs/tags/||' \
-            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -V \
             | tail -n1)
           echo "Latest consensus node tag: $LATEST_TAG"

--- a/.github/workflows/go_compatibility.yml
+++ b/.github/workflows/go_compatibility.yml
@@ -130,12 +130,11 @@ jobs:
         if: ${{ !inputs.consensus-node-version }}
         id: get-consensus-version
         run: |
-          # Fetch latest stable or RC version (excludes alpha, beta versions)
-          # TODO: revert to stable-only once v0.76.0 is released (see hiero-ledger/hiero-sdk-tck#671)
+          # Fetch latest stable version (excludes RC, beta, alpha versions)
           LATEST_TAG=$(git ls-remote --tags --refs https://github.com/hiero-ledger/hiero-consensus-node \
             | awk '{print $2}' \
             | sed 's|refs/tags/||' \
-            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -V \
             | tail -n1)
           echo "Latest consensus node tag: $LATEST_TAG"

--- a/.github/workflows/java_compatibility.yml
+++ b/.github/workflows/java_compatibility.yml
@@ -156,12 +156,11 @@ jobs:
         if: ${{ !inputs.consensus-node-version }}
         id: get-consensus-version
         run: |
-          # Fetch latest stable or RC version (excludes alpha, beta versions)
-          # TODO: revert to stable-only once v0.76.0 is released (see hiero-ledger/hiero-sdk-tck#671)
+          # Fetch latest stable version (excludes RC, beta, alpha versions)
           LATEST_TAG=$(git ls-remote --tags --refs https://github.com/hiero-ledger/hiero-consensus-node \
             | awk '{print $2}' \
             | sed 's|refs/tags/||' \
-            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -V \
             | tail -n1)
           echo "Latest consensus node tag: $LATEST_TAG"

--- a/.github/workflows/js_compatibility.yml
+++ b/.github/workflows/js_compatibility.yml
@@ -137,12 +137,11 @@ jobs:
         if: ${{ !inputs.consensus-node-version }}
         id: get-consensus-version
         run: |
-          # Fetch latest stable or RC version (excludes alpha, beta versions)
-          # TODO: revert to stable-only once v0.76.0 is released (see hiero-ledger/hiero-sdk-tck#671)
+          # Fetch latest stable version (excludes RC, beta, alpha versions)
           LATEST_TAG=$(git ls-remote --tags --refs https://github.com/hiero-ledger/hiero-consensus-node \
             | awk '{print $2}' \
             | sed 's|refs/tags/||' \
-            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' \
+            | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -V \
             | tail -n1)
           echo "Latest consensus node tag: $LATEST_TAG"


### PR DESCRIPTION
## Description

Reverts the temporary workaround from #671 that made the compatibility workflows resolve the latest consensus node version **including release-candidate tags**. The TODO said to revert once v0.76.0 was released — stable `v0.76.0` and `v0.76.1` are now out with published builds.

The workaround is currently breaking CI on every PR: the latest tag in hiero-consensus-node is `v0.77.0-rc.6`, but its build artifacts were never published to builds.hedera.com, so Solo network setup fails during "Fetch platform software":

```
SoloError: package URL 'https://builds.hedera.com/node/software/v0.77/build-v0.77.0-rc.6.sha384' does not exist
```

(verified: `v0.77.0-rc.6` → HTTP 404, while `v0.77.0-rc.5`, `v0.76.0`, `v0.76.1` → HTTP 200)

## Changes

- Restore the stable-only tag regex (`^v?[0-9]+\.[0-9]+\.[0-9]+$`) in the "Get Latest Consensus Node Version" step of all four compatibility workflows (JS, Java, Go, C++), as the TODO prescribed. With this change the workflows resolve `v0.76.1`.

## Related

- Fixes the CI failures seen on #680 (and any other open PR)
- Follow-up to the workaround introduced for #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Compatibility checks now use only stable consensus-node releases.
  * Release-candidate versions are excluded from automatic version selection across C++, Go, Java, and JavaScript workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->