### PR TITLE
docs: fix typo fileID -> fileId in FileDeleteTransaction output parameters

### DIFF
--- a/docs/test-specifications/file-service/FileDeleteTransaction.md
+++ b/docs/test-specifications/file-service/FileDeleteTransaction.md
@@ -37,7 +37,7 @@ https://docs.hedera.com/hedera/sdks-and-apis/rest-api
 
 | Parameter Name          | Type                                                    | Required/Optional | Description/Notes             |
 |-------------------------|---------------------------------------------------------|-------------------|-------------------------------|
-| fileID                  | string                                                  | optional          | The ID of the file to delete. |
+| fileId                  | string                                                  | optional          | The ID of the file to delete. |
 | commonTransactionParams | [json object](../common/CommonTransactionParameters.md) | optional          |                               |
 
 ### Output Parameters


### PR DESCRIPTION
Fixes a typo in `docs/test-specifications/file-service/FileDeleteTransaction.md` where the output parameter `fileID` was incorrectly capitalized and should be `fileId` (camelCase). Closes #692.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the file deletion specification to use the corrected `fileId` parameter name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->