### PR TITLE
ci: harden workflows for OpenSSF Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/cpp_compatibility.yml
+++ b/.github/workflows/cpp_compatibility.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Set up the tck-client
         run: |
             npm cache clean --force
-            npm install
+            npm ci
         working-directory: tck
 
       # Set up and start the TCK server

--- a/.github/workflows/go_compatibility.yml
+++ b/.github/workflows/go_compatibility.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up the tck-client
         run: |
             npm cache clean --force
-            npm install
+            npm ci
         working-directory: tck
 
       # Set up and start the TCK server

--- a/.github/workflows/java_compatibility.yml
+++ b/.github/workflows/java_compatibility.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set up the tck-client
         run: |
           npm cache clean --force
-          npm install
+          npm ci
         working-directory: tck
 
       # Set up and start the TCK server

--- a/.github/workflows/js_compatibility.yml
+++ b/.github/workflows/js_compatibility.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set up the tck-client
         run: |
           npm cache clean --force
-          npm install
+          npm ci
         working-directory: tck
 
       # Set up and start the TCK server

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 permissions:
-  statuses: write
+  contents: read
 
 concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -32,6 +32,8 @@ jobs:
   title-check:
     name: Title Check
     runs-on: hiero-client-sdk-linux-medium
+    permissions:
+      statuses: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/test-count.yml
+++ b/.github/workflows/test-count.yml
@@ -42,10 +42,7 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        run: npm install
-      
-      - name: Ensure TS types for libs
-        run: npm i -D @types/markdown-it @types/jsdom
+        run: npm ci
 
       - name: Run test count script
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:22-slim@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
 
 # Set working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,8 @@ ENV NETWORK=local \
 # Copy the rest of the application
 COPY . .
 
+RUN chown -R node:node /app
+USER node
+
 # Use the runner script
 CMD ["npx", "ts-node", "--files", "/app/src/services/RunTestsInContainer.ts"]


### PR DESCRIPTION
**Description**:

Raise the repository's [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/hiero-ledger/hiero-sdk-tck) score by tightening workflow token permissions and pinning the remaining unpinned dependencies. All changes are limited to `.github/` and the `Dockerfile`; no test or source code is touched.

**Changes**

*Token-Permissions*
* `pr_check.yml`: declare a read-only top-level token (`contents: read`) and move `statuses: write` down to the `title-check` job, the only job that needs it (the conventional-PR-title action sets a commit status). The `assignee-check` job never uses the token.

*Pinned-Dependencies*
* `Dockerfile`: pin `node:22-slim` by digest (`sha256:83f487e0…`, verified with `docker buildx imagetools inspect node:22-slim`).
* `js_compatibility.yml`, `go_compatibility.yml`, `cpp_compatibility.yml`, `java_compatibility.yml`: install the TCK client dependencies with `npm ci` instead of `npm install`, so the committed `package-lock.json` is used as-is (the `Dockerfile` already does this).
* `test-count.yml`: same `npm install` → `npm ci`; the follow-up `npm i -D @types/markdown-it @types/jsdom` step is removed because both packages are already listed in `devDependencies` and in the lockfile, so `npm ci` installs them.

*Dependabot*
* Add `.github/dependabot.yml` with weekly `github-actions`, `npm` and `docker` update schedules so the SHA/digest pins keep getting refreshed.

| Check | Before | After (local scorecard) |
| --- | --- | --- |
| Token-Permissions | 9 | 10 |
| Pinned-Dependencies | 7 | 9 |
| Dangerous-Workflow | 10 | 10 |
| Binary-Artifacts | 10 | 10 |

**Intentionally not changed**
* No CodeQL workflow is added. This repository already runs CodeQL via code scanning *default setup* (the `Analyze (actions)` / `Analyze (javascript-typescript)` check runs on `main`), and GitHub rejects SARIF uploads from an advanced-setup workflow while default setup is enabled ("CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled"). Scorecard's SAST check only reaches its full score when CodeQL results are attached to every PR; if maintainers want that, the path is to keep default setup and make sure it runs on all PR commits, or to switch to an advanced-setup workflow in the repository settings first.
* `js_compatibility.yml` "Install and Start TCK Server" still runs `npm install` in `sdk-server/tck`. That directory belongs to the checked-out `hiero-ledger/hiero-sdk-js` tag, and its lockfile cannot be guaranteed to be in sync across every tag the workflow may check out, so switching it to `npm ci` is left to a follow-up. This is the single remaining Pinned-Dependencies finding.
* `docker-compose.yml` image `ivaylogarnev/js-tck-server-amd` is a floating developer image and is not scored; left as-is.
* `pr_check.yml` keeps `pull_request_target`; it never checks out PR code, so it is not a dangerous-workflow pattern.
* No fuzzing/property tests were added: the suite is an integration suite that requires live consensus, mirror and JSON-RPC endpoints (see `src/preflight.ts`), and there is no unit-test harness to host one.

**Related issue(s)**:

N/A

**Notes for reviewer**:

Verification performed locally:
* `actionlint` on every touched workflow: no new findings versus `main` (only the pre-existing self-hosted runner-label notices and shellcheck style notes).
* `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow,SAST,Fuzzing` before/after, results in the table above.
* `npm ci --ignore-scripts` against the committed `package.json`/`package-lock.json` succeeds and installs `@types/markdown-it` and `@types/jsdom`.
* The image digest was resolved from the registry.

The `title-check` job keeps exactly the `statuses: write` scope it had before, so the PR-title status check behaviour is unchanged. The `Assignee Check` job needs a maintainer to assign the PR; contributors without write access cannot set an assignee.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Docker images are now pinned to a specific version for more predictable builds.
  * Containers run as a non-root user, improving runtime security.
  * Workflow permissions are more narrowly scoped.

* **Maintenance**
  * Automated weekly updates are enabled for project dependencies and build tools.
  * Dependency installation in automated checks now uses the lockfile for consistent results.
  * Redundant type-installation steps were removed from testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->