### PR TITLE
fix(tck): use bytes field in contract-call-query asserts

### DIFF
--- a/src/tests/contract-service/test-contract-call-query-bytes.ts
+++ b/src/tests/contract-service/test-contract-call-query-bytes.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { AbiCoder } from "ethers";
+import {
+  getContractCallResultHex,
+  getContractCallResultPayload,
+} from "@helpers/contract-call-result";
+
+const abiCoder = AbiCoder.defaultAbiCoder();
+
+function decodeFromCallQuery(
+  response: { rawResult?: unknown; bytes?: unknown },
+  types: string[],
+) {
+  const payload = getContractCallResultPayload(response);
+  expect(payload).to.not.be.null;
+  return abiCoder.decode(types, getContractCallResultHex(response))[0];
+}
+
+describe("ContractCallQuery result bytes (#703)", function () {
+  const encoded300 = abiCoder.encode(["uint256"], [300n]) as string;
+
+  it("decodes uint256 from spec-compliant bytes (already 0x-prefixed)", function () {
+    const response = { bytes: encoded300 };
+    const result = decodeFromCallQuery(response, ["uint256"]);
+    expect(result.toString()).to.equal("300");
+  });
+
+  it("does not double-prefix when the payload is already 0x-prefixed", function () {
+    expect(getContractCallResultHex({ bytes: encoded300 })).to.equal(
+      encoded300,
+    );
+    const result = abiCoder.decode(
+      ["uint256"],
+      getContractCallResultHex({ bytes: encoded300 }),
+    )[0];
+    expect(result.toString()).to.equal("300");
+  });
+
+  it("still decodes unprefixed rawResult from JS/Java/C++ TCK servers", function () {
+    const response = { rawResult: encoded300.slice(2) };
+    const result = decodeFromCallQuery(response, ["uint256"]);
+    expect(result.toString()).to.equal("300");
+  });
+
+  it("prefers bytes when both fields are present", function () {
+    const response = { bytes: encoded300, rawResult: "deadbeef" };
+    expect(getContractCallResultPayload(response)).to.equal(encoded300);
+    expect(
+      abiCoder
+        .decode(["uint256"], getContractCallResultHex(response))[0]
+        .toString(),
+    ).to.equal("300");
+  });
+
+  it("hex-encodes Uint8Array payloads", function () {
+    const bytes = Uint8Array.from(Buffer.from(encoded300.slice(2), "hex"));
+    expect(getContractCallResultHex({ bytes }).toLowerCase()).to.equal(
+      encoded300,
+    );
+  });
+});

--- a/src/tests/contract-service/test-contract-call-query.ts
+++ b/src/tests/contract-service/test-contract-call-query.ts
@@ -2,12 +2,16 @@ import { assert, expect } from "chai";
 import { ContractFunctionParameters } from "@hashgraph/sdk";
 import { JSONRPCRequest } from "@services/Client";
 import { setOperator } from "@helpers/setup-tests";
-import { AbiCoder } from 'ethers';
+import { AbiCoder } from "ethers";
 import {
   generateEd25519PrivateKey,
   generateEd25519PublicKey,
 } from "@helpers/key";
 import { toHexString } from "@helpers/verify-contract-tx";
+import {
+  getContractCallResultHex,
+  getContractCallResultPayload,
+} from "@helpers/contract-call-result";
 
 const abiCoder = AbiCoder.defaultAbiCoder();
 
@@ -130,7 +134,7 @@ describe("ContractCallQuery", function () {
       );
 
       expect(response).to.not.be.null;
-      expect(response.rawResult).to.not.be.null;
+      expect(getContractCallResultPayload(response)).to.not.be.null;
     });
 
     it("(#2) Fails to execute contract call query without contract ID", async function () {
@@ -198,7 +202,7 @@ describe("ContractCallQuery", function () {
         });
 
         expect(response).to.not.be.null;
-        expect(response.rawResult).to.not.be.null;
+        expect(getContractCallResultPayload(response)).to.not.be.null;
       } catch (err: any) {
         if (err.data?.status) {
           assert.equal(err.data.status, "INSUFFICIENT_GAS");
@@ -259,7 +263,7 @@ describe("ContractCallQuery", function () {
       );
 
       expect(response).to.not.be.null;
-      expect(response.rawResult).to.not.be.null;
+      expect(getContractCallResultPayload(response)).to.not.be.null;
     });
 
     it("(#2) Executes query with uint256 parameter", async function () {
@@ -275,8 +279,10 @@ describe("ContractCallQuery", function () {
         functionParams,
       );
 
-
-      const result = abiCoder.decode(['uint256'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint256"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
       expect(result.toString()).to.equal("300");
     });
@@ -342,8 +348,11 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getMessage"),
       );
 
-     const result = abiCoder.decode(['string'], `0x${response.rawResult}`)[0];
-     expect(result).to.equal("Hello from Hedera");
+      const result = abiCoder.decode(
+        ["string"],
+        getContractCallResultHex(response),
+      )[0];
+      expect(result).to.equal("Hello from Hedera");
     });
 
     it("(#2) Returns concatenated string value", async function () {
@@ -359,7 +368,10 @@ describe("ContractCallQuery", function () {
         functionParams,
       );
 
-      const result = abiCoder.decode(['string'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["string"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.equal("Hello World");
     });
 
@@ -373,7 +385,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getMessage"),
       );
 
-      const result = abiCoder.decode(['string'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["string"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.equal("");
     });
   });
@@ -393,7 +408,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getTrue"),
       );
 
-      const result = abiCoder.decode(['bool'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["bool"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.equal(true);
     });
 
@@ -405,7 +423,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getFalse"),
       );
 
-      const result = abiCoder.decode(['bool'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["bool"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.equal(false);
     });
 
@@ -417,7 +438,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getBool"),
       );
 
-      const result = abiCoder.decode(['bool'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["bool"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
       expect(typeof result).to.equal("boolean");
     });
@@ -438,7 +462,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt8"),
       );
 
-      const result = abiCoder.decode(['int8'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["int8"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -450,7 +477,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint8"),
       );
 
-      const result = abiCoder.decode(['uint8'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint8"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -462,7 +492,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt16"),
       );
 
-      const result = abiCoder.decode(['int16'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["int16"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -474,7 +507,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint16"),
       );
 
-      const result = abiCoder.decode(['uint16'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint16"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -486,7 +522,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt32"),
       );
 
-      const result = abiCoder.decode(['int32'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["int32"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -498,7 +537,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint32"),
       );
 
-      const result = abiCoder.decode(['uint32'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint32"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -510,7 +552,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt64"),
       );
 
-      const result = abiCoder.decode(['int64'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["int64"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -522,7 +567,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint64"),
       );
 
-      const result = abiCoder.decode(['uint64'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint64"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -534,8 +582,11 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt256"),
       );
 
-       const result = abiCoder.decode(['int256'], `0x${response.rawResult}`)[0];
-       expect(result).to.not.be.null;
+      const result = abiCoder.decode(
+        ["int256"],
+        getContractCallResultHex(response),
+      )[0];
+      expect(result).to.not.be.null;
     });
 
     it("(#10) Returns uint256 value", async function () {
@@ -546,7 +597,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint256"),
       );
 
-      const result = abiCoder.decode(['uint256'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint256"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -563,7 +617,10 @@ describe("ContractCallQuery", function () {
         functionParams,
       );
 
-      const result = abiCoder.decode(['uint256'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint256"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result.toString()).to.equal("300");
     });
 
@@ -575,7 +632,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt24"),
       );
 
-      const result = abiCoder.decode(['int24'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["int24"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -587,7 +647,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint24"),
       );
 
-      const result = abiCoder.decode(['uint24'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint24"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -599,7 +662,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt40"),
       );
 
-      const result = abiCoder.decode(['int40'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["int40"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -611,7 +677,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint40"),
       );
 
-      const result = abiCoder.decode(['uint40'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint40"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -623,7 +692,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt48"),
       );
 
-      const result = abiCoder.decode(['int48'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["int48"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -635,7 +707,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint48"),
       );
 
-      const result = abiCoder.decode(['uint48'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint48"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -647,7 +722,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getInt56"),
       );
 
-      const result = abiCoder.decode(['int56'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["int56"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -659,7 +737,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint56"),
       );
 
-      const result = abiCoder.decode(['uint56'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint56"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
   });
@@ -679,7 +760,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getAddress"),
       );
 
-      const result = abiCoder.decode(['address'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["address"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
       expect(result).to.match(/^0x[a-fA-F0-9]{40}$/);
     });
@@ -692,7 +776,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getSenderAddress"),
       );
 
-      const result = abiCoder.decode(['address'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["address"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
       expect(result).to.match(/^0x[a-fA-F0-9]{40}$/);
     });
@@ -713,7 +800,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getBytes32"),
       );
 
-      const result = abiCoder.decode(['bytes32'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["bytes32"],
+        getContractCallResultHex(response),
+      )[0];
       expect(result).to.not.be.null;
     });
 
@@ -725,7 +815,7 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getFixedBytes"),
       );
 
-      expect(response.rawResult).to.not.be.null;
+      expect(getContractCallResultPayload(response)).to.not.be.null;
     });
 
     it("(#3) Returns dynamic bytes value", async function () {
@@ -736,7 +826,7 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getDynamicBytes"),
       );
 
-      expect(response.rawResult).to.not.be.null;
+      expect(getContractCallResultPayload(response)).to.not.be.null;
     });
   });
 
@@ -755,7 +845,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint256Array"),
       );
 
-      const result = abiCoder.decode(['uint256[]'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint256[]"],
+        getContractCallResultHex(response),
+      )[0];
       expect(response).to.not.be.null;
       expect(result).to.not.be.null;
     });
@@ -768,8 +861,10 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getAddressArray"),
       );
 
-
-      const result = abiCoder.decode(['address[]'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["address[]"],
+        getContractCallResultHex(response),
+      )[0];
       expect(response).to.not.be.null;
       expect(result).to.not.be.null;
     });
@@ -791,7 +886,7 @@ describe("ContractCallQuery", function () {
       );
 
       expect(response).to.not.be.null;
-      expect(response.rawResult).to.not.be.null;
+      expect(getContractCallResultPayload(response)).to.not.be.null;
     });
 
     it("(#2) Returns multiple integer values", async function () {
@@ -803,7 +898,7 @@ describe("ContractCallQuery", function () {
       );
 
       expect(response).to.not.be.null;
-      expect(response.rawResult).to.not.be.null;
+      expect(getContractCallResultPayload(response)).to.not.be.null;
     });
   });
 
@@ -994,8 +1089,8 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getMessage"),
       );
 
-      expect(response.rawResult).to.not.be.null;
-      expect(response.rawResult).to.be.a("string");
+      expect(getContractCallResultPayload(response)).to.not.be.null;
+      expect(getContractCallResultPayload(response)).to.be.a("string");
     });
 
     it("(#2) Bytes field contains valid hex data", async function () {
@@ -1006,9 +1101,13 @@ describe("ContractCallQuery", function () {
         new ContractFunctionParameters()._build("getUint256"),
       );
 
-      const result = abiCoder.decode(['uint256'], `0x${response.rawResult}`)[0];
+      const result = abiCoder.decode(
+        ["uint256"],
+        getContractCallResultHex(response),
+      )[0];
       expect(response).to.not.be.null;
-      expect(response.rawResult).to.match(/^[a-fA-F0-9]+$/);
+      expect(result).to.not.be.null;
+      expect(getContractCallResultHex(response)).to.match(/^0x[a-fA-F0-9]+$/i);
     });
   });
 });

--- a/src/utils/helpers/contract-call-result.ts
+++ b/src/utils/helpers/contract-call-result.ts
@@ -1,0 +1,54 @@
+import { toHexString } from "./verify-contract-tx";
+
+/**
+ * JSON-RPC result of `contractCallQuery`.
+ *
+ * The TCK spec names the payload `bytes`. Some SDK TCK servers (JS, Java,
+ * C++) still send `rawResult`.
+ */
+export type ContractCallQueryResult = {
+  bytes?: unknown;
+  rawResult?: unknown;
+};
+
+/**
+ * Spec field `bytes`, falling back to `rawResult` for older TCK servers.
+ */
+export const getContractCallResultPayload = (
+  response: ContractCallQueryResult,
+): unknown => {
+  return response.bytes ?? response.rawResult;
+};
+
+const payloadToAbiHex = (payload: unknown): string => {
+  if (payload === null || payload === undefined) {
+    throw new Error(
+      "contractCallQuery response is missing bytes (and rawResult fallback)",
+    );
+  }
+
+  if (typeof payload === "string") {
+    const hex = payload.trim();
+    if (hex.length === 0) {
+      throw new Error("contractCallQuery result hex is empty");
+    }
+    return /^0x/i.test(hex) ? `0x${hex.slice(2)}` : `0x${hex}`;
+  }
+
+  if (payload instanceof Uint8Array) {
+    return `0x${toHexString(payload)}`;
+  }
+
+  throw new Error(
+    `contractCallQuery result has unsupported type: ${typeof payload}`,
+  );
+};
+
+/**
+ * Hex string with a single `0x` prefix, suitable for ethers AbiCoder.decode.
+ */
+export const getContractCallResultHex = (
+  response: ContractCallQueryResult,
+): string => {
+  return payloadToAbiHex(getContractCallResultPayload(response));
+};


### PR DESCRIPTION
## Summary

`contractCallQuery` tests read `response.rawResult` and always prefix `0x` before ABI-decoding. The TCK spec names the field `bytes`, and spec-compliant SDK TCK servers (for example Swift) already return a `0x`-prefixed hex string, so those cases fail with `0xundefined` or `0x0x…`.

This change:

- Reads `response.bytes`, falling back to `rawResult` for JS/Java/C++ servers that still use that name
- Normalizes hex so a `0x` prefix is applied at most once (Uint8Array payloads are hex-encoded)
- Keeps the existing non-null asserts on the chosen field

Credits @exploreriii for reporting the field mismatch and the double-prefix trap.

Fixes #703


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract-call result handling across supported response formats.
  * Added support for decoding prefixed byte payloads, raw results, and `Uint8Array` values into ABI-compatible data.
  * Ensured consistent preference for byte payloads when multiple result fields are available.

* **Tests**
  * Added coverage for byte decoding, fallback behavior, field precedence, and ABI decoding results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->