### PR TITLE
fix: keep preflight's socket timeout out of the tests' keep-alive pool

### DIFF
--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -28,6 +28,7 @@
  */
 import "dotenv/config";
 import { lookup } from "node:dns/promises";
+import { Agent } from "node:http";
 import { Socket } from "node:net";
 import {
   existsSync,
@@ -54,6 +55,14 @@ export const mochaHooks = {
 
 const TIMEOUT_MS = 5000;
 
+// The checks below set an axios `timeout`, which arms an idle timer on the
+// underlying socket. With Node's keep-alive global agent that socket goes
+// back into the pool still armed, and the first later JSON-RPC call that
+// takes longer than TIMEOUT_MS to answer (e.g. an SDK request timing out)
+// dies with "socket hang up". Give the checks their own non-pooling agent so
+// nothing they touch is reused by the tests.
+const preflightAgent = new Agent({ keepAlive: false });
+
 // What the endpoint's hostname actually resolves to on this machine — the
 // BNCE failure mode was /etc/hosts mapping the FQDN to 127.0.2.1.
 const resolvedAddress = async (host: string): Promise<string> => {
@@ -69,7 +78,11 @@ const resolvedAddress = async (host: string): Promise<string> => {
 const checkHttp = async (name: string, url: string): Promise<string | null> => {
   const { hostname } = new URL(url);
   try {
-    await axios.get(url, { timeout: TIMEOUT_MS, validateStatus: () => true });
+    await axios.get(url, {
+      timeout: TIMEOUT_MS,
+      validateStatus: () => true,
+      httpAgent: preflightAgent,
+    });
     return null;
   } catch (error: any) {
     return `${name} unreachable: ${url} (${hostname} resolved to ${await resolvedAddress(
@@ -119,7 +132,11 @@ const checkJsonRpcServer = async (
     const response = await axios.post(
       url,
       { jsonrpc: "2.0", id: "preflight-version", method: "version" },
-      { timeout: TIMEOUT_MS, validateStatus: () => true },
+      {
+        timeout: TIMEOUT_MS,
+        validateStatus: () => true,
+        httpAgent: preflightAgent,
+      },
     );
     const result = response.data?.result;
     const version =


### PR DESCRIPTION
### Description

Any JSON-RPC call that takes the SDK server more than ~5s to answer — an SDK request timing out, a long consensus wait — could fail on the driver side with `socket hang up` instead of receiving the server's response, and it hits whichever test happens to make the first such call in a run.

Cause: the preflight reachability checks (#662) pass a 5s axios `timeout`, which arms an idle timer on the socket. Node's keep-alive global agent returns that socket to the pool still armed, and the first test request that reuses it is cut off 5s in. Reproduced deterministically with a request that reuses the socket after `axios.post(url, body, { timeout: 5000 })`; a fresh socket, or a socket from a non-keep-alive agent, survives the same 30s+ request.

Fix: run the preflight checks through their own `new http.Agent({ keepAlive: false })` so nothing they touch is reused by the tests.

Found while verifying #689: ClientPing tests 4 and 5 (a ping against a blocked endpoint has to wait out the SDK server's 30s request timeout) failed with `socket hang up` until this change; with it they pass.

### Related
- #689 (stacked on this branch until it merges)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preflight HTTP reachability checks to avoid reusing idle connections.
  * Increased reliability of subsequent JSON-RPC test requests by preventing stale socket reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->